### PR TITLE
Fix Home Screen Created Section

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -43,7 +43,24 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        refreshGroups()
+    }
 
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View {
+        val rootView = inflater!!.inflate(R.layout.fragment_main, container, false)
+
+        val groupRecyclerView = rootView.findViewById<androidx.recyclerview.widget.RecyclerView>(R.id.group_list_recyclerView)
+        groupRecyclerView.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(rootView.context)
+        currentAdapter = GroupRecyclerAdapter(groups, callback)
+        groupRecyclerView.adapter = currentAdapter
+
+        setNoGroups()
+
+        return rootView
+    }
+
+    public fun refreshGroups() {
         CoroutineScope(Dispatchers.IO).launch {
             val groupRole = arguments?.getString(GroupFragment.GROUP_ROLE) ?: return@launch
             val getGroupsEndpoint = Endpoint.getAllGroups(groupRole)
@@ -68,20 +85,6 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
                 setNoGroups()
             }
         }
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?): View {
-        val rootView = inflater!!.inflate(R.layout.fragment_main, container, false)
-
-        val groupRecyclerView = rootView.findViewById<androidx.recyclerview.widget.RecyclerView>(R.id.group_list_recyclerView)
-        groupRecyclerView.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(rootView.context)
-        currentAdapter = GroupRecyclerAdapter(groups, callback)
-        groupRecyclerView.adapter = currentAdapter
-
-        setNoGroups()
-
-        return rootView
     }
 
     fun removeGroup(id: String) {
@@ -114,7 +117,6 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
                 noGroupsTitle.text = getString(R.string.no_groups_created_title)
                 noGroupsSubtext.text = getString(R.string.no_groups_created_subtext)
             }
-
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -50,8 +50,8 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
                               savedInstanceState: Bundle?): View {
         val rootView = inflater!!.inflate(R.layout.fragment_main, container, false)
 
-        val groupRecyclerView = rootView.findViewById<androidx.recyclerview.widget.RecyclerView>(R.id.group_list_recyclerView)
-        groupRecyclerView.layoutManager = androidx.recyclerview.widget.LinearLayoutManager(rootView.context)
+        val groupRecyclerView = rootView.findViewById<RecyclerView>(R.id.group_list_recyclerView)
+        groupRecyclerView.layoutManager = LinearLayoutManager(rootView.context)
         currentAdapter = GroupRecyclerAdapter(groups, callback)
         groupRecyclerView.adapter = currentAdapter
 
@@ -106,14 +106,20 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
         fragmentInteractionListener?.onFragmentInteraction(uri)
     }
 
+    /**
+     * Checks the number of groups and toggles the no groups view (empty state) if there are
+     * no groups. Should be called every time `groups` is modified.
+     */
     private fun setNoGroups() {
         if (noGroupsView != null) {
             noGroupsView.visibility = if (groups.isNotEmpty()) View.GONE else View.VISIBLE
 
             if ((arguments?.getString(GroupFragment.GROUP_ROLE) ?: return) == "member") {
+                noGroupsEmoji.text = getString(R.string.no_groups_joined_emoji)
                 noGroupsTitle.text = getString(R.string.no_groups_joined_title)
                 noGroupsSubtext.text = getString(R.string.no_groups_joined_subtext)
             } else {
+                noGroupsEmoji.text = getString(R.string.no_groups_created_emoji)
                 noGroupsTitle.text = getString(R.string.no_groups_created_title)
                 noGroupsSubtext.text = getString(R.string.no_groups_created_subtext)
             }

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -217,6 +217,12 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
     private fun finishAuthFlow() {
         // Create the adapter that will return a fragment for each of the three
         // primary sections of the activity.
+        if (mSectionsPagerAdapter != null) {
+            createdGroupFragment?.refreshGroups()
+            joinedGroupFragment?.refreshGroups()
+            return
+        }
+
         mSectionsPagerAdapter = SectionsPagerAdapter(supportFragmentManager)
 
         // Set up the ViewPager with the sections adapter.

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -268,11 +268,11 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
 
         override fun getItem(position: Int): Fragment {
             if (position == 0) {
-                joinedGroupFragment = joinedGroupFragment ?: GroupFragment.newInstance(position + 1, this@MainActivity)
+                joinedGroupFragment = joinedGroupFragment ?: GroupFragment.newInstance(position + 1, this@MainActivity, userRole = User.Role.MEMBER)
                 return joinedGroupFragment!!
             }
 
-            createdGroupFragment = createdGroupFragment ?: GroupFragment.newInstance(position + 1, this@MainActivity)
+            createdGroupFragment = createdGroupFragment ?: GroupFragment.newInstance(position + 1, this@MainActivity, userRole= User.Role.ADMIN)
             return createdGroupFragment!!
         }
 

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -31,17 +31,19 @@
                 android:textSize="38sp"/>
 
             <TextView
+                android:id="@+id/noGroupsTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/no_groups_title"
+                android:text="@string/no_groups_joined_title"
                 android:textSize="16sp"
                 android:textStyle="bold" />
 
             <TextView
+                android:id="@+id/noGroupsSubtext"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:alpha=".9"
-                android:text="@string/no_groups_subtext" />
+                android:text="@string/no_groups_joined_subtext" />
         </LinearLayout>
 
         <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -22,9 +22,10 @@
             android:visibility="invisible">
 
             <TextView
+                android:id="@+id/noGroupsEmoji"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/no_groups_emoji"
+                android:text="@string/no_groups_joined_emoji"
                 android:height="50dp"
                 android:background="@color/white"
                 android:width="50dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,7 +27,8 @@
 
     <string name="live_indicator">•</string>
 
-    <string name="no_groups_emoji">&#129335;</string>
+    <string name="no_groups_joined_emoji">&#129335;&#8205;&#9792;&#65039;</string>
+    <string name="no_groups_created_emoji">&#129335;&#8205;&#9794;&#65039;</string>
     <string name="no_groups_joined_title">No groups joined</string>
     <string name="no_groups_created_title">No groups created</string>
     <string name="no_groups_joined_subtext">Enter a code below to join a group!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,8 +28,10 @@
     <string name="live_indicator">•</string>
 
     <string name="no_groups_emoji">&#129335;</string>
-    <string name="no_groups_subtext">Enter a code below to join a group</string>
-    <string name="no_groups_title">No Groups Joined</string>
+    <string name="no_groups_joined_title">No groups joined</string>
+    <string name="no_groups_created_title">No groups created</string>
+    <string name="no_groups_joined_subtext">Enter a code below to join a group!</string>
+    <string name="no_groups_created_subtext">Tap \"+\" above to create a group!</string>
 
     <string name="pollo">Pollo</string>
     <string name="pollo_pronunciation">\'\'Poh-loh\'\'</string>


### PR DESCRIPTION
  <!-- Fix Home Screen Created Section -->

  ## Overview

Fixed the `Created` tab on the home screen so that it actually displays the groups the user created. Previously it just fetched all groups the user is a member of.

  ## Changes Made
Sorry that it’s hard to go through, Git yeeted (yote?) the diff, but my changes were:
- Changing `GroupFragment.kt` so that the `created` section actually displays polls the user created. (previously it just fetched all it was a member of)
    - Did this by adding in a param for the user's role to the factory method and passing that into the fragment’s `arguments`
- Changed the empty state text to match the new designs/be specific to each tab
- Fixed an existing bug where logging out then logging into a new account would fail to update the groups


  ## Next Steps

I chose not to update the groups in the `onResume` as many times that would be unnecessary, so we need to be careful to manually update the groups any time we perform an operation that alters the groups. Afaict the current `addGroup`/`leaveGroup` functionality does indeed update the groups.

  ## Screenshots (delete if not applicable)


  <details>

Groups tab


<img width="407" alt="Screen Shot 2019-09-27 at 5 47 01 PM" src="https://user-images.githubusercontent.com/35942769/65804136-dc3a0780-e14e-11e9-9cdb-59245de9e8b1.png">

Created tab


<img width="407" alt="Screen Shot 2019-09-27 at 5 46 32 PM" src="https://user-images.githubusercontent.com/35942769/65804160-eb20ba00-e14e-11e9-87d7-b7bd0a1b90ef.png">


  </details>
