### PR TITLE
Fixed Refresh Token Bug

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/PreferenceHelper.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PreferenceHelper.kt
@@ -8,13 +8,22 @@ class PreferencesHelper(context: Context) {
     private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
 
     var accessToken = preferences.getString(ACCESS_TOKEN, "")
-        set(value) = preferences.edit().putString(ACCESS_TOKEN, value).apply()
+        set(value) {
+            preferences.edit().putString(ACCESS_TOKEN, value).apply()
+            field = preferences.getString(ACCESS_TOKEN, "")
+        }
 
     var refreshToken = preferences.getString(REFRESH_TOKEN, "")
-        set(value) = preferences.edit().putString(REFRESH_TOKEN, value).apply()
+        set(value) {
+            preferences.edit().putString(REFRESH_TOKEN, value).apply()
+            field = preferences.getString(REFRESH_TOKEN, "")
+        }
 
     var expiresAt = preferences.getLong(EXPIRES_AT, 0L)
-        set(value) = preferences.edit().putLong(EXPIRES_AT, value).apply()
+        set(value) {
+            preferences.edit().putLong(EXPIRES_AT, value).apply()
+            field = preferences.getLong(EXPIRES_AT, 0L)
+        }
 
     companion object {
         private const val ACCESS_TOKEN = "data.source.prefs.ACCESS_TOKEN"


### PR DESCRIPTION
  ## Overview
 - Changed setters in preferences so that both the values and the underlying preferences are updated
 - Fixed a bug when refreshing the user session, previously it would fail to refresh as it would fetch a new token, but then use the old (since the value was updated in the underlying `PreferencesManager`, but not in the local `PreferenceHelper` instance)