### PR TITLE
Admin Group Page

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -49,10 +49,16 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View {
         val rootView = inflater!!.inflate(R.layout.fragment_main, container, false)
+        val role: Int
+        if (arguments?.getString(GroupFragment.GROUP_ROLE) == "admin") {
+            role = 1
+        } else {
+            role = 0
+        }
 
         val groupRecyclerView = rootView.findViewById<RecyclerView>(R.id.group_list_recyclerView)
         groupRecyclerView.layoutManager = LinearLayoutManager(rootView.context)
-        currentAdapter = GroupRecyclerAdapter(groups, callback)
+        currentAdapter = GroupRecyclerAdapter(groups, callback, role)
         groupRecyclerView.adapter = currentAdapter
 
         setNoGroups()

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
@@ -2,7 +2,6 @@ package com.cornellappdev.android.pollo
 
 import android.content.Intent
 import androidx.core.content.ContextCompat
-import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import android.view.ViewGroup
 import com.cornellappdev.android.pollo.models.ApiResponse

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class GroupRecyclerAdapter(private val groups: ArrayList<Group>, val callback: GroupFragment.OnMoreButtonPressedListener?) : androidx.recyclerview.widget.RecyclerView.Adapter<GroupRecyclerAdapter.ViewHolder>() {
+class GroupRecyclerAdapter(private val groups: ArrayList<Group>, val callback: GroupFragment.OnMoreButtonPressedListener?, val role: Int) : androidx.recyclerview.widget.RecyclerView.Adapter<GroupRecyclerAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GroupRecyclerAdapter.ViewHolder {
         val inflatedView = parent.inflate(R.layout.group_list_item, false)
@@ -65,6 +65,7 @@ class GroupRecyclerAdapter(private val groups: ArrayList<Group>, val callback: G
                 val pollsDateActivity = Intent(context, PollsDateActivity::class.java)
                 pollsDateActivity.putExtra("SORTED_POLLS", sortedPolls!!.data)
                 pollsDateActivity.putExtra("GROUP_NODE", group)
+                pollsDateActivity.putExtra("USER_ROLE",role)
                 context.startActivity(pollsDateActivity)
 
                 view.groupDetailsButton.visibility = View.VISIBLE

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.cornellappdev.android.pollo.models.ApiResponse
 import com.cornellappdev.android.pollo.models.Group
+import com.cornellappdev.android.pollo.models.User
 import com.cornellappdev.android.pollo.networking.*
 import com.google.gson.reflect.TypeToken
 import kotlinx.android.synthetic.main.group_list_item.view.*
@@ -14,7 +15,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class GroupRecyclerAdapter(private val groups: ArrayList<Group>, val callback: GroupFragment.OnMoreButtonPressedListener?, val role: Int) : androidx.recyclerview.widget.RecyclerView.Adapter<GroupRecyclerAdapter.ViewHolder>() {
+class GroupRecyclerAdapter(
+        private val groups: ArrayList<Group>,
+        val callback: GroupFragment.OnMoreButtonPressedListener?,
+        val role: User.Role
+) : androidx.recyclerview.widget.RecyclerView.Adapter<GroupRecyclerAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GroupRecyclerAdapter.ViewHolder {
         val inflatedView = parent.inflate(R.layout.group_list_item, false)

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -210,6 +210,7 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
             val pollsDateActivity = Intent(this@MainActivity, PollsDateActivity::class.java)
             pollsDateActivity.putExtra("SORTED_POLLS", sortedPolls.data)
             pollsDateActivity.putExtra("GROUP_NODE", groupResponse.data)
+            pollsDateActivity.putExtra("USER_ROLE", 0)
             startActivity(pollsDateActivity)
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -210,7 +210,7 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
             val pollsDateActivity = Intent(this@MainActivity, PollsDateActivity::class.java)
             pollsDateActivity.putExtra("SORTED_POLLS", sortedPolls.data)
             pollsDateActivity.putExtra("GROUP_NODE", groupResponse.data)
-            pollsDateActivity.putExtra("USER_ROLE", 0)
+            pollsDateActivity.putExtra("USER_ROLE", User.Role.MEMBER)
             startActivity(pollsDateActivity)
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollFragment.java
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollFragment.java
@@ -58,7 +58,7 @@ public class PollFragment extends Fragment {
         final RecyclerView pollRecyclerView = rootView.findViewById(R.id.poll_list_recyclerView);
         pollRecyclerView.setLayoutManager(new LinearLayoutManager(rootView.getContext()));
 
-        currentAdapter = new GroupRecyclerAdapter(new ArrayList<Group>(), null);
+        currentAdapter = new GroupRecyclerAdapter(new ArrayList<Group>(), null,0);
         pollRecyclerView.setAdapter(currentAdapter);
         // new RetrieveGroupsTask().execute(new Util().new Triple(rootView, currentAdapter, this.sectionNumber));
         return rootView;

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollFragment.java
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollFragment.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import com.cornellappdev.android.pollo.models.Group;
+import com.cornellappdev.android.pollo.models.User;
 
 import java.util.ArrayList;
 
@@ -58,7 +59,7 @@ public class PollFragment extends Fragment {
         final RecyclerView pollRecyclerView = rootView.findViewById(R.id.poll_list_recyclerView);
         pollRecyclerView.setLayoutManager(new LinearLayoutManager(rootView.getContext()));
 
-        currentAdapter = new GroupRecyclerAdapter(new ArrayList<Group>(), null,0);
+        currentAdapter = new GroupRecyclerAdapter(new ArrayList<Group>(), null, User.Role.MEMBER);
         pollRecyclerView.setAdapter(currentAdapter);
         // new RetrieveGroupsTask().execute(new Util().new Triple(rootView, currentAdapter, this.sectionNumber));
         return rootView;

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
@@ -35,9 +35,12 @@ class PollsDateActivity : AppCompatActivity() {
 
         if (intent.getIntExtra("USER_ROLE", 0) == 1) {
             role = User.Role.ADMIN
+            noPollsTitle.setText(R.string.no_polls_created_title)
+            noPollsSubtext.setText(R.string.no_polls_created_subtext)
         } else {
             role = User.Role.MEMBER
             adminFooter.visibility = View.GONE
+            newPollImageButton.visibility = View.GONE
         }
 
         toggleEmptyState()

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
@@ -16,7 +16,7 @@ import kotlinx.android.synthetic.main.fragment_main.*
 import java.text.SimpleDateFormat
 import java.util.*
 
-class PollsDateActivity : AppCompatActivity() {
+class PollsDateActivity : AppCompatActivity(), View.OnClickListener {
 
     private lateinit var adapter: PollsDateRecyclerAdapter
     private lateinit var group: Group
@@ -33,14 +33,20 @@ class PollsDateActivity : AppCompatActivity() {
         sortedPolls = groupByDate(intent.getParcelableArrayListExtra<GetSortedPollsResponse>("SORTED_POLLS"))
         group = intent.getParcelableExtra("GROUP_NODE")
 
-        if (intent.getIntExtra("USER_ROLE", 0) == 1) {
-            role = User.Role.ADMIN
-            noPollsTitle.setText(R.string.no_polls_created_title)
-            noPollsSubtext.setText(R.string.no_polls_created_subtext)
-        } else {
-            role = User.Role.MEMBER
-            adminFooter.visibility = View.GONE
-            newPollImageButton.visibility = View.GONE
+        backButton.setOnClickListener(this)
+
+        // Customize page for role
+        role = intent.getSerializableExtra("USER_ROLE") as User.Role
+
+        when (role) {
+            User.Role.ADMIN -> {
+                noPollsTitle.setText(R.string.no_polls_created_title)
+                noPollsSubtext.setText(R.string.no_polls_created_subtext)
+            }
+            User.Role.MEMBER -> {
+                adminFooter.visibility = View.GONE
+                newPollImageButton.visibility = View.GONE
+            }
         }
 
         toggleEmptyState()
@@ -60,6 +66,11 @@ class PollsDateActivity : AppCompatActivity() {
 
     fun goBack(view: View) {
         finish()
+    }
+
+    override fun onClick(view: View) {
+        if (view.id == R.id.backButton)
+            goBack(view)
     }
 
     private fun toggleEmptyState() {

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
@@ -5,11 +5,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.View
 import com.cornellappdev.android.pollo.models.Group
+import com.cornellappdev.android.pollo.models.User
 import com.cornellappdev.android.pollo.networking.GetSortedPollsResponse
 import com.cornellappdev.android.pollo.networking.PollsResponse
 import com.cornellappdev.android.pollo.networking.Socket
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import kotlinx.android.synthetic.main.activity_polls_date.*
+import kotlinx.android.synthetic.main.activity_polls_date.noPollsView
+import kotlinx.android.synthetic.main.fragment_main.*
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -18,6 +21,7 @@ class PollsDateActivity : AppCompatActivity() {
     private lateinit var adapter: PollsDateRecyclerAdapter
     private lateinit var group: Group
     private lateinit var linearLayoutManager: androidx.recyclerview.widget.LinearLayoutManager
+    private lateinit var role: User.Role
     private lateinit var socket: Socket
 
     private var sortedPolls = ArrayList<GetSortedPollsResponse>()
@@ -28,6 +32,15 @@ class PollsDateActivity : AppCompatActivity() {
         setContentView(R.layout.activity_polls_date)
         sortedPolls = groupByDate(intent.getParcelableArrayListExtra<GetSortedPollsResponse>("SORTED_POLLS"))
         group = intent.getParcelableExtra("GROUP_NODE")
+
+        if (intent.getIntExtra("USER_ROLE", 0) == 1) {
+            role = User.Role.ADMIN
+        } else {
+            role = User.Role.MEMBER
+            adminFooter.visibility = View.GONE
+        }
+
+        toggleEmptyState()
 
         // Use LinearLayoutManager because we just want one cell per row
         linearLayoutManager = androidx.recyclerview.widget.LinearLayoutManager(this)
@@ -44,6 +57,18 @@ class PollsDateActivity : AppCompatActivity() {
 
     fun goBack(view: View) {
         finish()
+    }
+
+    private fun toggleEmptyState() {
+        if (sortedPolls.count() == 0) {
+            noPollsView.visibility = View.VISIBLE
+            adminFooter.visibility = View.GONE
+        } else {
+            noPollsView.visibility = View.GONE
+            if (role == User.Role.ADMIN) {
+                adminFooter.visibility = View.VISIBLE
+            }
+        }
     }
 
     fun groupByDate(sortedPolls: ArrayList<GetSortedPollsResponse>): ArrayList<GetSortedPollsResponse> {

--- a/app/src/main/res/drawable/plus_sign_white.xml
+++ b/app/src/main/res/drawable/plus_sign_white.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8.001,0L8.001,0A0.889,0.889 0,0 1,8.89 0.889L8.89,15.111A0.889,0.889 0,0 1,8.001 16L8.001,16A0.889,0.889 0,0 1,7.112 15.111L7.112,0.889A0.889,0.889 0,0 1,8.001 0z"
+      android:fillColor="#fff"/>
+  <path
+      android:pathData="M16,8L16,8A0.889,0.889 0,0 1,15.111 8.889L0.889,8.889A0.889,0.889 0,0 1,0 8L0,8A0.889,0.889 0,0 1,0.889 7.111L15.111,7.111A0.889,0.889 0,0 1,16 8z"
+      android:fillColor="#fff"/>
+</vector>

--- a/app/src/main/res/drawable/rounded_export_button.xml
+++ b/app/src/main/res/drawable/rounded_export_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient android:startColor="@color/black"
+        android:endColor="@color/black"
+        android:angle="270" />
+    <corners android:radius="3dp" />
+    <stroke android:width="5px" android:color="@color/cool_grey" />
+</shape>

--- a/app/src/main/res/drawable/rounded_join_button.xml
+++ b/app/src/main/res/drawable/rounded_join_button.xml
@@ -2,7 +2,7 @@
 <!--  res/drawable/rounded_edittext.xml -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle" android:padding="10dp">
-    <solid android:color="@color/blueyGrey"/>
+    <solid android:color="@color/cool_grey"/>
     <corners
         android:bottomRightRadius="3dp"
         android:bottomLeftRadius="3dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -72,7 +72,7 @@
                 app:tabBackground="@color/white"
                 app:tabSelectedTextColor="@color/colorAccent"
                 app:tabTextAppearance="@style/TabItemNotAllCaps"
-                app:tabTextColor="@color/blueyGrey">
+                app:tabTextColor="@color/cool_grey">
 
                 <com.google.android.material.tabs.TabItem
                     android:id="@+id/tabItem"

--- a/app/src/main/res/layout/activity_poll_group.xml
+++ b/app/src/main/res/layout/activity_poll_group.xml
@@ -41,7 +41,7 @@
                 android:layout_height="wrap_content"
                 android:text="Code: APPDEV"
                 android:textAppearance="@style/TextAppearance.AppCompat.Body2"
-                android:textColor="@color/blueyGrey"
+                android:textColor="@color/cool_grey"
                 android:textSize="12sp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_polls_date.xml
+++ b/app/src/main/res/layout/activity_polls_date.xml
@@ -22,6 +22,7 @@
                 android:layout_marginBottom="20dp">
 
                 <ImageButton
+                    android:id="@+id/backButton"
                     android:background="@color/black"
                     android:contentDescription="@string/go_back_content_description"
                     android:layout_alignParentStart="true"
@@ -29,7 +30,6 @@
                     android:layout_height="32dp"
                     android:layout_marginStart="15dp"
                     android:layout_width="32dp"
-                    android:onClick="goBack"
                     android:src="@drawable/arrow_back" />
 
                 <TextView

--- a/app/src/main/res/layout/activity_polls_date.xml
+++ b/app/src/main/res/layout/activity_polls_date.xml
@@ -5,66 +5,153 @@
     android:layout_width="match_parent"
     tools:context=".PollsDateActivity">
 
-    <LinearLayout
-        android:background="@color/black"
-        android:layout_height="match_parent"
+    <ScrollView
         android:layout_width="match_parent"
-        android:orientation="vertical">
-
-        <RelativeLayout
+        android:layout_height="match_parent"
+        android:background="@color/black">
+        <LinearLayout
             android:background="@color/black"
-            android:layout_height="65dp"
-            android:layout_width="match_parent">
-
-            <ImageButton
-                android:background="@color/black"
-                android:contentDescription="@string/go_back_content_description"
-                android:layout_alignParentStart="true"
-                android:layout_centerVertical="true"
-                android:layout_height="14dp"
-                android:layout_marginStart="15dp"
-                android:layout_width="14dp"
-                android:onClick="goBack"
-                android:src="@drawable/arrow_back" />
-
-            <TextView
-                android:id="@+id/groupNameTextView"
-                android:layout_width="match_parent"
-                android:layout_height="30dp"
-                android:layout_centerHorizontal="true"
-                android:layout_marginTop="14dp"
-                android:fontFamily="sans-serif"
-                android:text="Example Course"
-                android:textAlignment="center"
-                android:textColor="@color/white"
-                android:textSize="20sp"
-                android:textStyle="bold"
-                tools:ignore="HardcodedText" />
-
-            <TextView
-                android:id="@+id/codeTextView"
-                android:layout_width="match_parent"
-                android:layout_height="20dp"
-                android:layout_below="@id/groupNameTextView"
-                android:alpha="0.75"
-                android:fontFamily="sans-serif-medium"
-                android:text="Code: 123ABC"
-                android:textAlignment="center"
-                android:textColor="@color/white"
-                android:textSize="14sp"
-                tools:ignore="HardcodedText" />
-
-        </RelativeLayout>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/pollsDateRecyclerView"
             android:layout_height="match_parent"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
             android:layout_width="match_parent"
-            android:scrollbars="vertical" />
+            android:orientation="vertical">
 
-    </LinearLayout>
+            <RelativeLayout
+                android:background="@color/black"
+                android:layout_height="65dp"
+                android:layout_width="match_parent"
+                android:layout_marginBottom="20dp">
 
+                <ImageButton
+                    android:background="@color/black"
+                    android:contentDescription="@string/go_back_content_description"
+                    android:layout_alignParentStart="true"
+                    android:layout_centerVertical="true"
+                    android:layout_height="14dp"
+                    android:layout_marginStart="15dp"
+                    android:layout_width="14dp"
+                    android:onClick="goBack"
+                    android:src="@drawable/arrow_back" />
+
+                <TextView
+                    android:id="@+id/groupNameTextView"
+                    android:layout_width="match_parent"
+                    android:layout_height="30dp"
+                    android:layout_centerHorizontal="true"
+                    android:layout_marginTop="14dp"
+                    android:fontFamily="sans-serif"
+                    android:text="Example Course"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/codeTextView"
+                    android:layout_width="match_parent"
+                    android:layout_height="20dp"
+                    android:layout_below="@id/groupNameTextView"
+                    android:alpha="0.75"
+                    android:fontFamily="sans-serif-medium"
+                    android:text="Code: 123ABC"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="14sp"
+                    tools:ignore="HardcodedText" />
+
+                <ImageButton
+                    android:id="@+id/newPollImageButton"
+                    android:background="@color/black"
+                    android:layout_centerVertical="true"
+                    android:layout_alignParentEnd="true"
+                    android:layout_height="16dp"
+                    android:layout_width="16dp"
+                    android:layout_marginEnd="16dp"
+                    android:src="@drawable/arrow_back" />
+
+            </RelativeLayout>
+
+            <LinearLayout
+                android:id="@+id/noPollsView"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:layout_marginBottom="50dp"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:visibility="invisible">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/no_polls_emoji"
+                    android:textSize="38sp"
+                    android:layout_marginBottom="16dp"/>
+
+                <TextView
+                    android:id="@+id/noPollsTitle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/no_polls_title"
+                    android:textSize="18sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/white"
+                    android:layout_marginBottom="8dp"/>
+
+                <TextView
+                    android:id="@+id/noPollsSubtext"
+                    android:layout_width="228dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/no_polls_subtext"
+                    android:textSize="14sp"
+                    android:textAlignment="center"
+                    android:textColor="@color/cool_grey"/>
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/pollsDateRecyclerView"
+                android:layout_height="match_parent"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_width="match_parent"
+                android:scrollbars="vertical" />
+
+            <LinearLayout
+                android:id="@+id/adminFooter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginBottom="50dp"
+                android:gravity="center"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/viewAllButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/view_all"
+                    android:textColor="@color/polloGreen"
+                    android:textSize="16sp"
+                    android:textAllCaps="false"
+                    android:background="@color/black"
+                    android:layout_marginBottom="24dp" />
+
+                <Button
+                    android:id="@+id/exportButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="50dp"
+                    android:paddingEnd="50dp"
+                    android:paddingTop="12dp"
+                    android:paddingBottom="12dp"
+                    android:text="@string/export"
+                    android:textColor="@color/cool_grey"
+                    android:textSize="16sp"
+                    android:textAllCaps="false"
+                    android:background="@drawable/rounded_export_button" />
+            </LinearLayout>
+
+        </LinearLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_polls_date.xml
+++ b/app/src/main/res/layout/activity_polls_date.xml
@@ -26,9 +26,9 @@
                     android:contentDescription="@string/go_back_content_description"
                     android:layout_alignParentStart="true"
                     android:layout_centerVertical="true"
-                    android:layout_height="14dp"
+                    android:layout_height="32dp"
                     android:layout_marginStart="15dp"
-                    android:layout_width="14dp"
+                    android:layout_width="32dp"
                     android:onClick="goBack"
                     android:src="@drawable/arrow_back" />
 
@@ -64,10 +64,10 @@
                     android:background="@color/black"
                     android:layout_centerVertical="true"
                     android:layout_alignParentEnd="true"
-                    android:layout_height="16dp"
-                    android:layout_width="16dp"
+                    android:layout_height="32dp"
+                    android:layout_width="32dp"
                     android:layout_marginEnd="16dp"
-                    android:src="@drawable/arrow_back" />
+                    android:src="@drawable/plus_sign_white" />
 
             </RelativeLayout>
 
@@ -76,6 +76,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_gravity="center"
+                android:layout_marginTop="50dp"
                 android:layout_marginBottom="50dp"
                 android:gravity="center"
                 android:orientation="vertical"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,7 +4,7 @@
     <color name="colorPrimaryDark">@color/bluishGreen</color>
     <color name="colorAccent">@color/black</color>
 
-    <color name="blueyGrey">#9ea7b3</color>
+    <color name="cool_grey">#9ea7b3</color>
     <color name="cardHeaderGray">#fafafa</color>
     <color name="paleGray">#f5f7f8</color>
     <color name="white">#f6f6f6</color>
@@ -20,6 +20,7 @@
     <color name="joinGroupGray">#9B9A9A</color>
     <color name="joinGroupUnderline">#85514F4F</color>
     <color name="pollsDateBackgroundColor">#3D3D3D</color>
+    <color name="polloGreen">#29C09E</color>
     <color name="multipleChoiceBorderColor">#9fa5b1</color>
     <color name="multipleChoiceIncorrectAnswerColor">#c4c4c4</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,12 +27,22 @@
 
     <string name="live_indicator">•</string>
 
+<!--Home Screen Empty State Strings-->
     <string name="no_groups_joined_emoji">&#129335;&#8205;&#9792;&#65039;</string>
     <string name="no_groups_created_emoji">&#129335;&#8205;&#9794;&#65039;</string>
     <string name="no_groups_joined_title">No groups joined</string>
     <string name="no_groups_created_title">No groups created</string>
     <string name="no_groups_joined_subtext">Enter a code below to join a group!</string>
     <string name="no_groups_created_subtext">Tap \"+\" above to create a group!</string>
+
+<!--Group Screen Strings-->
+    <string name="no_polls_emoji">&#128584;</string>
+    <string name="no_polls_title">Nothing to see yet</string>
+    <string name="no_polls_created_title">Nothing to see here</string>
+    <string name="no_polls_subtext">Waiting for the admin to post a poll…</string>
+    <string name="no_polls_created_subtext">You haven’t made any polls yet! Tap “+” above to try it out.</string>
+    <string name="view_all">View All</string>
+    <string name="export">Export</string>
 
     <string name="pollo">Pollo</string>
     <string name="pollo_pronunciation">\'\'Poh-loh\'\'</string>


### PR DESCRIPTION
  ## Overview

Added the admin-side designs to the group page:
 - Add poll button
 - Export button
 - View all button
Added the empty-state views for students and admins
Passed in the user role in each of the entry points to the group page

  ## Changes Made

 - Changed `activity_polls_date.xml` to include empty state view and admin views
 - Changed `GroupFragment` and `GroupRecyclerView` to pass user role to the group page
 - Changed `PollsDateActivity` to display/hide empty state and admin views as needed

  ## Screenshots


  <details>

    <summary>Admin View</summary>

<img width="407" alt="Screen Shot 2019-10-16 at 6 16 07 PM" src="https://user-images.githubusercontent.com/35942769/66963396-98e20300-f041-11e9-8064-6d463703b7a7.png">


    <summary>Student Empty State</summary>

<img width="407" alt="Screen Shot 2019-10-16 at 6 23 11 PM" src="https://user-images.githubusercontent.com/35942769/66964712-6934fa00-f045-11e9-97a2-3e02933dcd32.png">

    <summary>Admin Empty State</summary>

<img width="407" alt="Screen Shot 2019-10-16 at 6 47 23 PM" src="https://user-images.githubusercontent.com/35942769/66964732-72be6200-f045-11e9-8dea-a676016094e9.png">

  </details>
