### PR TITLE
UI changes for group creation

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -66,22 +66,21 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
             val hasSixCharacters = s?.length == 6
-            join_group_button.isEnabled = hasSixCharacters
+            joinGroupButton.isEnabled = hasSixCharacters
             val correctBackground = if (hasSixCharacters) R.drawable.rounded_join_button_filled else R.drawable.rounded_join_button
-            join_group_button.setBackgroundResource(correctBackground)
+            joinGroupButton.setBackgroundResource(correctBackground)
         }
     }
 
     private val createPollTextWatcher = object : TextWatcher {
-
         override fun afterTextChanged(s: Editable?) {}
         override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
             val hasText = s?.length != 0
-            create_group_button.isEnabled = hasText
+            createGroupButton.isEnabled = hasText
             val correctBackground = if (hasText) R.drawable.rounded_join_button_filled else R.drawable.rounded_join_button
-            create_group_button.setBackgroundResource(correctBackground)
+            createGroupButton.setBackgroundResource(correctBackground)
         }
     }
 
@@ -89,40 +88,39 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        edit_text_join_group.filters = edit_text_join_group.filters + InputFilter.AllCaps()
-        edit_text_join_group.addTextChangedListener(joinPollTextWatcher)
-        edit_text_join_group.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> edit_text_join_group.isCursorVisible = hasFocus }
-        edit_text_join_group.setOnEditorActionListener { _, actionId, _ ->
+        editTextJoinGroup.filters = editTextJoinGroup.filters + InputFilter.AllCaps()
+        editTextJoinGroup.addTextChangedListener(joinPollTextWatcher)
+        editTextJoinGroup.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> editTextJoinGroup.isCursorVisible = hasFocus }
+        editTextJoinGroup.setOnEditorActionListener { _, actionId, _ ->
             when (actionId) {
                 EditorInfo.IME_ACTION_DONE, EditorInfo.IME_ACTION_NEXT, EditorInfo.IME_ACTION_SEARCH -> {
-                    edit_text_join_group.isCursorVisible = false
+                    editTextJoinGroup.isCursorVisible = false
                     true
                 }
                 else -> {
-                    edit_text_join_group.isCursorVisible = true
+                    editTextJoinGroup.isCursorVisible = true
                     false
                 }
             }
         }
 
-        edit_text_create_group.addTextChangedListener(createPollTextWatcher)
-        edit_text_create_group.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> edit_text_create_group.isCursorVisible = hasFocus }
-        edit_text_create_group.setOnEditorActionListener { _, actionId, _ ->
+        editTextCreateGroup.addTextChangedListener(createPollTextWatcher)
+        editTextCreateGroup.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> editTextCreateGroup.isCursorVisible = hasFocus }
+        editTextCreateGroup.setOnEditorActionListener { _, actionId, _ ->
             when (actionId) {
                 EditorInfo.IME_ACTION_DONE, EditorInfo.IME_ACTION_NEXT, EditorInfo.IME_ACTION_SEARCH -> {
-                    edit_text_create_group.isCursorVisible = false
+                    editTextCreateGroup.isCursorVisible = false
                     true
                 }
                 else -> {
-                    edit_text_create_group.isCursorVisible = true
+                    editTextCreateGroup.isCursorVisible = true
                     false
                 }
             }
         }
 
-
-        edit_text_create_group.visibility = View.GONE
-        create_group_button.visibility = View.GONE
+        editTextCreateGroup.visibility = View.GONE
+        createGroupButton.visibility = View.GONE
 
         container.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
 
@@ -134,16 +132,16 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
             override fun onPageSelected(position: Int) {
                 when (position) {
                     0 -> {
-                        edit_text_create_group.visibility = View.GONE
-                        create_group_button.visibility = View.GONE
-                        edit_text_join_group.visibility = View.VISIBLE
-                        join_group_button.visibility = View.VISIBLE
+                        editTextCreateGroup.visibility = View.GONE
+                        createGroupButton.visibility = View.GONE
+                        editTextJoinGroup.visibility = View.VISIBLE
+                        joinGroupButton.visibility = View.VISIBLE
                     }
                     1 -> {
-                        edit_text_create_group.visibility = View.VISIBLE
-                        create_group_button.visibility = View.VISIBLE
-                        edit_text_join_group.visibility = View.GONE
-                        join_group_button.visibility = View.GONE
+                        editTextCreateGroup.visibility = View.VISIBLE
+                        createGroupButton.visibility = View.VISIBLE
+                        editTextJoinGroup.visibility = View.GONE
+                        joinGroupButton.visibility = View.GONE
                     }
                 }
             }
@@ -167,13 +165,13 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
         }
 
         // Add listener for when join and create buttons are pressed
-        join_group_button.setOnClickListener {
-            joinGroup(edit_text_join_group.text.toString())
-            edit_text_join_group.setText("")
+        joinGroupButton.setOnClickListener {
+            joinGroup(editTextJoinGroup.text.toString())
+            editTextJoinGroup.setText("")
         }
-        create_group_button.setOnClickListener {
-            createGroup(edit_text_create_group.text.toString())
-            edit_text_create_group.setText("")
+        createGroupButton.setOnClickListener {
+            createGroup(editTextCreateGroup.text.toString())
+            editTextCreateGroup.setText("")
         }
 
         val account = GoogleSignIn.getLastSignedInAccount(this)

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -18,7 +18,6 @@ import android.util.Log
 import android.view.View
 import android.view.animation.TranslateAnimation
 import android.view.inputmethod.EditorInfo
-import android.widget.EditText
 import com.cornellappdev.android.pollo.models.ApiResponse
 import com.cornellappdev.android.pollo.models.Group
 import com.cornellappdev.android.pollo.models.GroupCode
@@ -67,9 +66,22 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
             val hasSixCharacters = s?.length == 6
-            join_poll_group.isEnabled = hasSixCharacters
+            join_group_button.isEnabled = hasSixCharacters
             val correctBackground = if (hasSixCharacters) R.drawable.rounded_join_button_filled else R.drawable.rounded_join_button
-            join_poll_group.setBackgroundResource(correctBackground)
+            join_group_button.setBackgroundResource(correctBackground)
+        }
+    }
+
+    private val createPollTextWatcher = object : TextWatcher {
+
+        override fun afterTextChanged(s: Editable?) {}
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            val hasText = s?.length != 0
+            create_group_button.isEnabled = hasText
+            val correctBackground = if (hasText) R.drawable.rounded_join_button_filled else R.drawable.rounded_join_button
+            create_group_button.setBackgroundResource(correctBackground)
         }
     }
 
@@ -77,22 +89,40 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val editText = findViewById<EditText>(R.id.edit_text_join_poll)
-        editText.filters = editText.filters + InputFilter.AllCaps()
-        editText.addTextChangedListener(joinPollTextWatcher)
-        editText.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> editText.isCursorVisible = hasFocus }
-        editText.setOnEditorActionListener { _, actionId, _ ->
+        edit_text_join_group.filters = edit_text_join_group.filters + InputFilter.AllCaps()
+        edit_text_join_group.addTextChangedListener(joinPollTextWatcher)
+        edit_text_join_group.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> edit_text_join_group.isCursorVisible = hasFocus }
+        edit_text_join_group.setOnEditorActionListener { _, actionId, _ ->
             when (actionId) {
                 EditorInfo.IME_ACTION_DONE, EditorInfo.IME_ACTION_NEXT, EditorInfo.IME_ACTION_SEARCH -> {
-                    editText.isCursorVisible = false
+                    edit_text_join_group.isCursorVisible = false
                     true
                 }
                 else -> {
-                    editText.isCursorVisible = true
+                    edit_text_join_group.isCursorVisible = true
                     false
                 }
             }
         }
+
+        edit_text_create_group.addTextChangedListener(createPollTextWatcher)
+        edit_text_create_group.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> edit_text_create_group.isCursorVisible = hasFocus }
+        edit_text_create_group.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
+                EditorInfo.IME_ACTION_DONE, EditorInfo.IME_ACTION_NEXT, EditorInfo.IME_ACTION_SEARCH -> {
+                    edit_text_create_group.isCursorVisible = false
+                    true
+                }
+                else -> {
+                    edit_text_create_group.isCursorVisible = true
+                    false
+                }
+            }
+        }
+
+
+        edit_text_create_group.visibility = View.GONE
+        create_group_button.visibility = View.GONE
 
         container.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
 
@@ -104,18 +134,16 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
             override fun onPageSelected(position: Int) {
                 when (position) {
                     0 -> {
-                        join_poll_group.setText(R.string.join_button_text)
-                        join_poll_group.setOnClickListener {
-                            joinGroup(editText.text.toString())
-                            editText.setText("")
-                        }
+                        edit_text_create_group.visibility = View.GONE
+                        create_group_button.visibility = View.GONE
+                        edit_text_join_group.visibility = View.VISIBLE
+                        join_group_button.visibility = View.VISIBLE
                     }
                     1 -> {
-                        join_poll_group.setText(R.string.create_button_text)
-                        join_poll_group.setOnClickListener {
-                            createGroup(editText.text.toString())
-                            editText.setText("")
-                        }
+                        edit_text_create_group.visibility = View.VISIBLE
+                        create_group_button.visibility = View.VISIBLE
+                        edit_text_join_group.visibility = View.GONE
+                        join_group_button.visibility = View.GONE
                     }
                 }
             }
@@ -138,10 +166,14 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
             dismissPopup()
         }
 
-        // Add listener for when join button is pressed
-        join_poll_group.setOnClickListener {
-            joinGroup(editText.text.toString())
-            editText.setText("")
+        // Add listener for when join and create buttons are pressed
+        join_group_button.setOnClickListener {
+            joinGroup(edit_text_join_group.text.toString())
+            edit_text_join_group.setText("")
+        }
+        create_group_button.setOnClickListener {
+            createGroup(edit_text_create_group.text.toString())
+            edit_text_create_group.setText("")
         }
 
         val account = GoogleSignIn.getLastSignedInAccount(this)

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
@@ -91,9 +91,7 @@ class PollsDateActivity : AppCompatActivity(), SocketDelegate, View.OnClickListe
             adminFooter.visibility = View.GONE
         } else {
             noPollsView.visibility = View.GONE
-            if (role == User.Role.ADMIN) {
-                adminFooter.visibility = View.VISIBLE
-            }
+            if (role == User.Role.ADMIN) adminFooter.visibility = View.VISIBLE
         }
     }
 

--- a/app/src/main/res/drawable/rounded_join_button_filled.xml
+++ b/app/src/main/res/drawable/rounded_join_button_filled.xml
@@ -2,7 +2,7 @@
 <!--  res/drawable/rounded_edittext.xml -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle" android:padding="10dp">
-    <solid android:color="@color/colorPrimary"/>
+    <solid android:color="@color/polloGreen"/>
     <corners
         android:bottomRightRadius="3dp"
         android:bottomLeftRadius="3dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -119,7 +119,7 @@
                 android:layout_width="match_parent">
 
                 <EditText
-                    android:id="@+id/edit_text_join_group"
+                    android:id="@+id/editTextJoinGroup"
                     android:layout_width="0dp"
                     android:layout_height="50dp"
                     android:layout_marginStart="19dp"
@@ -139,13 +139,13 @@
                     android:textCursorDrawable="@drawable/custom_cursor"
                     android:textSize="16sp"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/join_group_button"
+                    app:layout_constraintEnd_toStartOf="@id/joinGroupButton"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:ignore="UnusedAttribute" />
 
                 <EditText
-                    android:id="@+id/edit_text_create_group"
+                    android:id="@+id/editTextCreateGroup"
                     android:layout_width="0dp"
                     android:layout_height="50dp"
                     android:layout_marginStart="19dp"
@@ -163,13 +163,13 @@
                     android:textCursorDrawable="@drawable/custom_cursor"
                     android:textSize="16sp"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/create_group_button"
+                    app:layout_constraintEnd_toStartOf="@id/createGroupButton"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:ignore="UnusedAttribute" />
 
                 <Button
-                    android:id="@+id/join_group_button"
+                    android:id="@+id/joinGroupButton"
                     android:layout_width="68dp"
                     android:layout_height="32dp"
                     android:layout_marginEnd="19dp"
@@ -189,7 +189,7 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <Button
-                    android:id="@+id/create_group_button"
+                    android:id="@+id/createGroupButton"
                     android:layout_width="84dp"
                     android:layout_height="32dp"
                     android:layout_marginEnd="19dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -119,7 +119,7 @@
                 android:layout_width="match_parent">
 
                 <EditText
-                    android:id="@+id/edit_text_join_poll"
+                    android:id="@+id/edit_text_join_group"
                     android:layout_width="0dp"
                     android:layout_height="50dp"
                     android:layout_marginStart="19dp"
@@ -138,15 +138,38 @@
                     android:textColorHint="@color/joinGroupGray"
                     android:textCursorDrawable="@drawable/custom_cursor"
                     android:textSize="16sp"
-                    android:textAllCaps="false"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/join_poll_group"
+                    app:layout_constraintEnd_toStartOf="@id/join_group_button"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:ignore="UnusedAttribute" />
+
+                <EditText
+                    android:id="@+id/edit_text_create_group"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:layout_marginStart="19dp"
+                    android:layout_marginEnd="35dp"
+                    android:layout_weight="1"
+                    android:autofillHints="none"
+                    android:backgroundTint="@color/joinGroupUnderline"
+                    android:cursorVisible="false"
+                    android:enabled="true"
+                    android:fontFamily="sans-serif"
+                    android:hint="@string/create_a_group_placeholder"
+                    android:textAlignment="viewStart"
+                    android:textColor="@color/joinGroupGray"
+                    android:textColorHint="@color/joinGroupGray"
+                    android:textCursorDrawable="@drawable/custom_cursor"
+                    android:textSize="16sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/create_group_button"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
                     tools:ignore="UnusedAttribute" />
 
                 <Button
-                    android:id="@+id/join_poll_group"
+                    android:id="@+id/join_group_button"
                     android:layout_width="68dp"
                     android:layout_height="32dp"
                     android:layout_marginEnd="19dp"
@@ -155,6 +178,26 @@
                     android:focusable="true"
                     android:fontFamily="sans-serif"
                     android:text="@string/join_button_text"
+                    android:textAllCaps="false"
+                    android:textColor="@color/white"
+                    android:textColorHighlight="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    android:visibility="visible"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <Button
+                    android:id="@+id/create_group_button"
+                    android:layout_width="84dp"
+                    android:layout_height="32dp"
+                    android:layout_marginEnd="19dp"
+                    android:background="@drawable/rounded_join_button"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:fontFamily="sans-serif"
+                    android:text="@string/create_button_text"
                     android:textAllCaps="false"
                     android:textColor="@color/white"
                     android:textColorHighlight="@color/black"


### PR DESCRIPTION
  ## Overview

  Added a new `EditText` and `Button` for group creation, readded some empty state code on the group pages that got deleted.



  ## Changes Made

  - Changes in the layout and logic for `MainActivity` to have a separate bottom bar for creation
 - Changes in `PollsDatActivity` for empty state

  ## Screenshots

  <details>

    <summary>Group Creation</summary>


<img width="407" alt="Screen Shot 2019-10-27 at 10 27 33 AM" src="https://user-images.githubusercontent.com/35942769/67636189-769f7f00-f8a4-11e9-8278-91e014f16915.png">



  </details>
