### PR TITLE
Group Options Menu Refactor [1/2] (#34)

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.android.pollo
 
 import android.annotation.SuppressLint
 import android.app.AlertDialog
+import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -10,14 +11,15 @@ import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.TranslateAnimation
 import com.cornellappdev.android.pollo.models.ApiResponse
 import com.cornellappdev.android.pollo.models.Group
 import com.cornellappdev.android.pollo.models.User
-import com.cornellappdev.android.pollo.networking.Endpoint
-import com.cornellappdev.android.pollo.networking.Request
-import com.cornellappdev.android.pollo.networking.getAllGroups
+import com.cornellappdev.android.pollo.networking.*
 import com.google.gson.reflect.TypeToken
+import kotlinx.android.synthetic.main.activity_main.dimView
 import kotlinx.android.synthetic.main.fragment_main.*
+import kotlinx.android.synthetic.main.manage_group_view.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -33,13 +35,14 @@ import java.util.*
  * create an instance of this fragment.
  */
 @SuppressLint("ValidFragment")
-class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
+class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListener {
 
     private var sectionNumber: Int = 0
     private var currentAdapter: GroupRecyclerAdapter? = null
     private val fragmentInteractionListener: OnFragmentInteractionListener? = null
 
     private var groups = ArrayList<Group>()
+    private var groupSelected: Group? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,17 +55,84 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
         val role = arguments?.getSerializable(GroupFragment.GROUP_ROLE) as User.Role
         val groupRecyclerView = rootView.findViewById<RecyclerView>(R.id.group_list_recyclerView)
         groupRecyclerView.layoutManager = LinearLayoutManager(rootView.context)
-        currentAdapter = GroupRecyclerAdapter(groups, callback, role)
+        currentAdapter = GroupRecyclerAdapter(groups, this, role)
         groupRecyclerView.adapter = currentAdapter
-
-        setNoGroups()
 
         return rootView
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setNoGroups()
+
+        val groupRole = arguments?.getSerializable(GROUP_ROLE) as User.Role? ?: return
+
+        when (groupRole) {
+            User.Role.MEMBER -> {
+                groupMenuOptionsView.editGroupName.visibility = View.GONE
+                groupMenuOptionsView.deleteGroup.visibility = View.GONE
+                groupMenuOptionsView.leaveGroup.visibility = View.VISIBLE
+            }
+            User.Role.ADMIN -> {
+                groupMenuOptionsView.editGroupName.visibility = View.VISIBLE
+                groupMenuOptionsView.deleteGroup.visibility = View.VISIBLE
+                groupMenuOptionsView.leaveGroup.visibility = View.GONE
+            }
+        }
+
+        // Setup options menu for groups
+        groupMenuOptionsView.closeButton.setOnClickListener {
+            dismissPopup()
+        }
+
+        groupMenuOptionsView.leaveGroup.setOnClickListener {
+            val groupId = groupSelected?.id ?: return@setOnClickListener
+            val leaveGroupEndpoint = Endpoint.leaveGroup(groupId)
+
+            CoroutineScope(Dispatchers.IO).launch {
+                val typeToken = object : TypeToken<ApiResponse<String>>() {}.type
+                val response = Request.makeRequest<ApiResponse<String>>(leaveGroupEndpoint.okHttpRequest(), typeToken)
+
+                if (response?.success ?: return@launch) {
+                    withContext(Dispatchers.Main) {
+                        removeGroup(groupId)
+                        dismissPopup()
+                    }
+                }
+            }
+        }
+
+        groupMenuOptionsView.editGroupName.setOnClickListener {
+            // TODO(#40)
+        }
+
+        groupMenuOptionsView.deleteGroup.setOnClickListener {
+            val groupId = groupSelected?.id ?: return@setOnClickListener
+            val deleteGroupEndpoint = Endpoint.deleteGroup(groupId)
+
+            CoroutineScope(Dispatchers.IO).launch {
+                val typeToken = object : TypeToken<ApiResponse<String>>() {}.type
+                val response = Request.makeRequest<ApiResponse<String>>(deleteGroupEndpoint.okHttpRequest(), typeToken)
+
+                if (response?.success ?: return@launch) {
+                    withContext(Dispatchers.Main) {
+                        removeGroup(groupId)
+                        dismissPopup()
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        // TODO: setup delegation to MainActivity
+    }
+
     public fun refreshGroups() {
         CoroutineScope(Dispatchers.IO).launch {
-            val groupRole = arguments?.getSerializable(GroupFragment.GROUP_ROLE) as User.Role? ?: return@launch
+            val groupRole = arguments?.getSerializable(GROUP_ROLE) as User.Role? ?: return@launch
             val getGroupsEndpoint = Endpoint.getAllGroups(groupRole.name.toLowerCase())
             val typeTokenGroups = object : TypeToken<ApiResponse<ArrayList<Group>>>() {}.type
             val getGroupsResponse = Request.makeRequest<ApiResponse<ArrayList<Group>>>(getGroupsEndpoint.okHttpRequest(), typeTokenGroups)
@@ -114,7 +184,7 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
         if (noGroupsView != null) {
             noGroupsView.visibility = if (groups.isNotEmpty()) View.GONE else View.VISIBLE
 
-            when (arguments?.getSerializable(GroupFragment.GROUP_ROLE) as User.Role) {
+            when (arguments?.getSerializable(GROUP_ROLE) as User.Role) {
                 User.Role.MEMBER -> {
                     noGroupsEmoji.text = getString(R.string.no_groups_joined_emoji)
                     noGroupsTitle.text = getString(R.string.no_groups_joined_title)
@@ -129,14 +199,32 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
         }
     }
 
-
-    interface OnMoreButtonPressedListener {
-        fun onMoreButtonPressed(group: Group?)
-    }
-
     interface OnFragmentInteractionListener {
         // TODO: Update argument type and name
         fun onFragmentInteraction(uri: Uri)
+    }
+
+    override fun onMoreButtonPressed(group: Group?) {
+//        manageDim(true)
+        groupSelected = group
+        groupMenuOptionsView.groupNameTextView.text = group?.name ?: "Pollo Group"
+        groupMenuOptionsView.visibility = View.VISIBLE
+        val animate = TranslateAnimation(0f, 0f, groupMenuOptionsView.height.toFloat(), 0f)
+        animate.duration = 300
+        animate.fillAfter = true
+        groupMenuOptionsView.startAnimation(animate)
+    }
+
+    private fun dismissPopup() {
+//        manageDim(false)
+//        dimView.isClickable = false
+//        dimView.isFocusable = false
+        val animate = TranslateAnimation(0f, 0f, 0f, groupMenuOptionsView.height.toFloat())
+        animate.duration = 300
+        animate.fillAfter = true
+        groupMenuOptionsView.startAnimation(animate)
+        groupMenuOptionsView.visibility = View.INVISIBLE
+        groupSelected = null
     }
 
 
@@ -149,8 +237,8 @@ class GroupFragment(val callback: OnMoreButtonPressedListener) : Fragment() {
          * Returns a new instance of this fragment for the given section
          * number.
          */
-        fun newInstance(sectionNumber: Int, callback: OnMoreButtonPressedListener, userRole: User.Role): GroupFragment {
-            val fragment = GroupFragment(callback)
+        fun newInstance(sectionNumber: Int, userRole: User.Role): GroupFragment {
+            val fragment = GroupFragment()
             val args = Bundle()
             fragment.sectionNumber = sectionNumber
             args.putInt(ARG_SECTION_NUMBER, sectionNumber)

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.withContext
 
 class GroupRecyclerAdapter(
         private val groups: ArrayList<Group>,
-        val callback: GroupFragment.OnMoreButtonPressedListener?,
+        val callback: OnMoreButtonPressedListener?,
         val role: User.Role
 ) : androidx.recyclerview.widget.RecyclerView.Adapter<GroupRecyclerAdapter.ViewHolder>() {
 
@@ -112,6 +112,10 @@ class GroupRecyclerAdapter(
 
     internal fun getItem(index: Int): Group {
         return groups[index]
+    }
+
+    interface OnMoreButtonPressedListener {
+        fun onMoreButtonPressed(group: Group?)
     }
 
     companion object {

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -126,7 +126,6 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
         editTextCreateGroup.visibility = View.GONE
         createGroupButton.visibility = View.GONE
         editGroupName.visibility = View.GONE
-        endPoll.visibility = View.GONE
         deleteGroup.visibility = View.GONE
         leaveGroup.visibility = View.VISIBLE
 
@@ -149,7 +148,6 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
                         joinGroupButton.visibility = View.VISIBLE
 
                         editGroupName.visibility = View.GONE
-                        endPoll.visibility = View.GONE
                         deleteGroup.visibility = View.GONE
                         leaveGroup.visibility = View.VISIBLE
                     }
@@ -160,7 +158,6 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
                         joinGroupButton.visibility = View.GONE
 
                         editGroupName.visibility = View.VISIBLE
-                        endPoll.visibility = View.VISIBLE
                         deleteGroup.visibility = View.VISIBLE
                         leaveGroup.visibility = View.GONE
                     }
@@ -192,11 +189,7 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
         }
 
         groupMenuOptionsView.editGroupName.setOnClickListener {
-            // TODO
-        }
-
-        groupMenuOptionsView.endPoll.setOnClickListener {
-            // TODO
+            // TODO(#40)
         }
 
         groupMenuOptionsView.deleteGroup.setOnClickListener {
@@ -225,8 +218,8 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
 
             // Only reset the view's position if we're changing tabs
             // If we're not, there will be an animation that has not ended
-            if ( view.animation==null || view.animation.hasEnded()) {
-                if (oldTop > top) {
+            if ( view.animation==null || view.animation.hasEnded() ) {
+                if ( oldTop > top ) {
                     view.top = view.top + (oldTop - top)
                 } else {
                     view.top = view.top + (top - oldTop)

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -4,6 +4,7 @@ import android.animation.ObjectAnimator
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.Intent
+import android.content.res.Resources
 import android.os.Bundle
 import com.google.android.material.tabs.TabLayout
 import androidx.fragment.app.Fragment
@@ -27,6 +28,7 @@ import com.cornellappdev.android.pollo.networking.*
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.gson.reflect.TypeToken
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.manage_group_view.*
 import kotlinx.android.synthetic.main.manage_group_view.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -88,6 +90,7 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        // Joining group bottom bar setup
         editTextJoinGroup.filters = editTextJoinGroup.filters + InputFilter.AllCaps()
         editTextJoinGroup.addTextChangedListener(joinPollTextWatcher)
         editTextJoinGroup.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> editTextJoinGroup.isCursorVisible = hasFocus }
@@ -104,6 +107,7 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
             }
         }
 
+        // Creating group bottom bar setup
         editTextCreateGroup.addTextChangedListener(createPollTextWatcher)
         editTextCreateGroup.onFocusChangeListener = View.OnFocusChangeListener { v, hasFocus -> editTextCreateGroup.isCursorVisible = hasFocus }
         editTextCreateGroup.setOnEditorActionListener { _, actionId, _ ->
@@ -121,6 +125,13 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
 
         editTextCreateGroup.visibility = View.GONE
         createGroupButton.visibility = View.GONE
+        editGroupName.visibility = View.GONE
+        endPoll.visibility = View.GONE
+        deleteGroup.visibility = View.GONE
+        leaveGroup.visibility = View.VISIBLE
+
+        joinGroupButton.isEnabled = false
+        createGroupButton.isEnabled = false
 
         container.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
 
@@ -136,12 +147,24 @@ class MainActivity : AppCompatActivity(), GroupFragment.OnMoreButtonPressedListe
                         createGroupButton.visibility = View.GONE
                         editTextJoinGroup.visibility = View.VISIBLE
                         joinGroupButton.visibility = View.VISIBLE
+
+                        editGroupName.visibility = View.GONE
+                        endPoll.visibility = View.GONE
+                        deleteGroup.visibility = View.GONE
+                        leaveGroup.visibility = View.VISIBLE
                     }
                     1 -> {
                         editTextCreateGroup.visibility = View.VISIBLE
                         createGroupButton.visibility = View.VISIBLE
                         editTextJoinGroup.visibility = View.GONE
                         joinGroupButton.visibility = View.GONE
+
+                        editGroupName.visibility = View.VISIBLE
+                        endPoll.visibility = View.VISIBLE
+                        deleteGroup.visibility = View.VISIBLE
+                        leaveGroup.visibility = View.GONE
+
+//                        groupMenuOptionsView.y = groupMenuOptionsView.y + (589 - 325)
                     }
                 }
             }

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -152,26 +152,6 @@ class MainActivity : AppCompatActivity() {
 
         })
 
-
-
-//        groupMenuOptionsView.addOnLayoutChangeListener { view, _, top, _, _, _, oldTop, _, _ ->
-//            // Need to change the position of the view when the tabs change since it changes size
-//            // If not, the top of the view will appear when we switch to the created tab
-//
-//            // Don't do anything if this is the initial layout
-//            if ( oldTop == 0 ) return@addOnLayoutChangeListener
-//
-//            // Only reset the view's position if we're changing tabs
-//            // If we're not, there will be an animation that has not ended
-//            if ( view.animation==null || view.animation.hasEnded() ) {
-//                if ( oldTop > top ) {
-//                    view.top = view.top + (oldTop - top)
-//                } else {
-//                    view.top = view.top + (top - oldTop)
-//                }
-//            }
-//        }
-
         // Add listener for when join and create buttons are pressed
         joinGroupButton.setOnClickListener {
             joinGroup(editTextJoinGroup.text.toString())

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
@@ -25,7 +25,7 @@ fun Endpoint.Companion.leaveGroup(id: String): Endpoint {
     return Endpoint("/sessions/$id/members", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), method = EndpointMethod.DELETE)
 }
 
-fun Endpoint.Companion.deleteGroup(id: Int): Endpoint {
+fun Endpoint.Companion.deleteGroup(id: String): Endpoint {
     return Endpoint("/sessions/$id", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), method = EndpointMethod.DELETE)
 }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
@@ -8,11 +8,7 @@ import org.json.JSONObject
 
 fun Endpoint.Companion.joinGroupWithCode(code: String): Endpoint {
     val codeJSON = JSONObject()
-    try {
-        codeJSON.put("code", code)
-    } catch (e: JSONException) {
-        e.printStackTrace()
-    }
+    codeJSON.put("code", code)
     val requestBody = RequestBody.create(MediaType.get("application/json; charset=utf-8"), codeJSON.toString())
     return Endpoint(path = "/join/session", headers = mapOf("Authorization" to "Bearer " + User.currentSession.accessToken), body = requestBody, method = EndpointMethod.POST)
 }
@@ -31,23 +27,15 @@ fun Endpoint.Companion.deleteGroup(id: String): Endpoint {
 
 fun Endpoint.Companion.renameGroup(id: Int, name: String): Endpoint {
     val nameJSON = JSONObject()
-    try {
-        nameJSON.put("name", name)
-    } catch (e: JSONException) {
-        e.printStackTrace()
-    }
+    nameJSON.put("name", name)
     val requestBody = RequestBody.create(MediaType.get("application/json; charset=utf-8"), nameJSON.toString())
     return Endpoint("/sessions/$id", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), body = requestBody, method = EndpointMethod.PUT)
 }
 
 fun Endpoint.Companion.startSession(code: String, name: String) : Endpoint {
     val codeJSON = JSONObject()
-    try {
-        codeJSON.put("code", code)
-        codeJSON.put("name", name)
-    } catch (e: JSONException) {
-        e.printStackTrace()
-    }
+    codeJSON.put("code", code)
+    codeJSON.put("name", name)
     val requestBody = RequestBody.create(MediaType.get("application/json; charset=utf-8"), codeJSON.toString())
 
     return Endpoint("/start/session/", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), body = requestBody, method = EndpointMethod.POST)

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
@@ -25,6 +25,10 @@ fun Endpoint.Companion.leaveGroup(id: String): Endpoint {
     return Endpoint("/sessions/$id/members", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), method = EndpointMethod.DELETE)
 }
 
+fun Endpoint.Companion.deleteGroup(id: Int): Endpoint {
+    return Endpoint("/sessions/$id", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), method = EndpointMethod.DELETE)
+}
+
 fun Endpoint.Companion.startSession(code: String, name: String) : Endpoint {
     val codeJSON = JSONObject()
     try {

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
@@ -29,6 +29,17 @@ fun Endpoint.Companion.deleteGroup(id: Int): Endpoint {
     return Endpoint("/sessions/$id", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), method = EndpointMethod.DELETE)
 }
 
+fun Endpoint.Companion.renameGroup(id: Int, name: String): Endpoint {
+    val nameJSON = JSONObject()
+    try {
+        nameJSON.put("name", name)
+    } catch (e: JSONException) {
+        e.printStackTrace()
+    }
+    val requestBody = RequestBody.create(MediaType.get("application/json; charset=utf-8"), nameJSON.toString())
+    return Endpoint("/sessions/$id", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), body = requestBody, method = EndpointMethod.PUT)
+}
+
 fun Endpoint.Companion.startSession(code: String, name: String) : Endpoint {
     val codeJSON = JSONObject()
     try {

--- a/app/src/main/res/drawable/ic_edit_pencil.xml
+++ b/app/src/main/res/drawable/ic_edit_pencil.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+  <path
+      android:pathData="M37.444,486.558a11.964,11.964 0,0 0,3.236 -0.446l110.314,-30.9a12,12 0,0 0,5.248 -3.07l326.8,-326.8a12,12 0,0 0,0 -16.97L403.63,28.958a12,12 0,0 0,-16.97 0l-326.8,326.8a12,12 0,0 0,-3.07 5.248L25.888,471.32a12,12 0,0 0,11.556 15.238ZM147.824,426.617L84.89,364.669 339.913,109.646l63.922,60.96ZM395.145,54.417 L457.586,116.858 420.811,153.634L356.888,92.67ZM74.2,387.825l50.594,49.8L54.754,457.246Z"
+      android:fillColor="#000000"/>
+</vector>

--- a/app/src/main/res/drawable/ic_trash_can.xml
+++ b/app/src/main/res/drawable/ic_trash_can.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+  <path
+      android:pathData="M64.1,18.8L64.1,7.5L34.8,7.5v11.3L10.4,18.8v6.1h7.3l5.2,67.7h53.3l5.2,-67.7h8.3v-6.1L64.1,18.8zM58.1,13.5v5.2L40.9,18.7v-5.2L58.1,13.5zM28.4,86.4l-4.7,-61.6h51.5l-4.8,61.6L28.4,86.4z"
+      android:fillColor="@color/red"/>
+  <path
+      android:pathData="M46.4,33.6h6.1v44.3h-6.1z"
+      android:fillColor="@color/red"/>
+  <path
+      android:pathData="M63.701,78.086l-6.091,-0.331l2.407,-44.333l6.091,0.331z"
+      android:fillColor="@color/red"/>
+  <path
+      android:pathData="M35.186,78.085l-2.402,-44.333l6.091,-0.33l2.402,44.333z"
+      android:fillColor="@color/red"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -43,16 +43,6 @@
                     app:layout_constraintVertical_bias="0.66" />
 
                 <ImageView
-                    android:id="@+id/imageView2"
-                    android:layout_width="22dp"
-                    android:layout_height="24dp"
-                    android:layout_marginTop="24dp"
-                    android:layout_marginEnd="20dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:srcCompat="@drawable/ic_plus_sign" />
-
-                <ImageView
                     android:id="@+id/imageView3"
                     android:layout_width="40dp"
                     android:layout_height="40dp"
@@ -213,8 +203,4 @@
 
         </RelativeLayout>
     </RelativeLayout>
-
-    <include
-        layout="@layout/manage_group_view"
-        android:id="@+id/groupMenuOptionsView"/>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -1,10 +1,14 @@
+<RelativeLayout
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.cornellappdev.android.pollo.MainActivity$PlaceholderFragment">
+    android:layout_height="match_parent" >
 
 
     <FrameLayout
@@ -56,4 +60,15 @@
 
         </androidx.recyclerview.widget.RecyclerView>
     </FrameLayout>
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>
+    <include
+        layout="@layout/manage_group_view"
+        android:id="@+id/groupMenuOptionsView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignBottom="@id/constraintLayout"
+        />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -61,7 +61,6 @@
         </androidx.recyclerview.widget.RecyclerView>
     </FrameLayout>
 
-
 </androidx.constraintlayout.widget.ConstraintLayout>
     <include
         layout="@layout/manage_group_view"

--- a/app/src/main/res/layout/fragment_poll_group.xml
+++ b/app/src/main/res/layout/fragment_poll_group.xml
@@ -3,8 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context="com.cornellappdev.android.pollo.MainActivity$PlaceholderFragment">
+    android:layout_height="match_parent">
 
 
     <FrameLayout

--- a/app/src/main/res/layout/manage_group_view.xml
+++ b/app/src/main/res/layout/manage_group_view.xml
@@ -53,8 +53,8 @@
 
 
         <ImageView
-            android:layout_height="19dp"
-            android:layout_width="19dp"
+            android:layout_height="21dp"
+            android:layout_width="21dp"
             android:layout_marginStart="20dp"
             android:layout_gravity="center_vertical"
             android:src="@drawable/ic_edit_pencil"/>
@@ -74,7 +74,7 @@
     <LinearLayout
         android:clickable="true"
         android:focusable="true"
-        android:id="@+id/deleteGroup"
+        android:id="@+id/removeGroup"
         android:layout_height="wrap_content"
         android:layout_marginTop="21dp"
         android:paddingBottom="21dp"
@@ -84,52 +84,19 @@
         tools:ignore="UseCompoundDrawables">
 
         <ImageView
-            android:layout_height="18dp"
-            android:layout_width="16dp"
-            android:layout_marginStart="22dp"
-            android:layout_gravity="center_vertical"
-            android:src="@drawable/ic_trash_can" />
-
-        <TextView
-            android:fontFamily="sans-serif-medium"
-            android:layout_gravity="center_vertical"
-            android:layout_marginStart="31dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/delete_group"
-            android:textColor="@color/red"
-            android:textSize="18sp" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/leaveGroup"
-        android:clickable="true"
-        android:focusable="true"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="21dp"
-        android:paddingBottom="21dp"
-        android:layout_width="match_parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/divider"
-        tools:ignore="UseCompoundDrawables">
-
-        <ImageView
+            android:id="@+id/removeGroupImage"
             android:layout_height="22dp"
             android:layout_width="20dp"
             android:layout_marginStart="20dp"
-            android:layout_gravity="center_vertical"
-            android:rotation="180"
-            android:contentDescription="@string/leave_group_content_description"
-            android:src="@drawable/leave_group_red" />
+            android:layout_gravity="center_vertical" />
 
         <TextView
+            android:id="@+id/removeGroupText"
             android:fontFamily="sans-serif-medium"
             android:layout_gravity="center_vertical"
             android:layout_marginStart="31dp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/leave_group"
             android:textColor="@color/red"
             android:textSize="18sp" />
 

--- a/app/src/main/res/layout/manage_group_view.xml
+++ b/app/src/main/res/layout/manage_group_view.xml
@@ -88,7 +88,6 @@
             android:layout_width="16dp"
             android:layout_marginStart="22dp"
             android:layout_gravity="center_vertical"
-            android:rotation="180"
             android:src="@drawable/ic_trash_can" />
 
         <TextView

--- a/app/src/main/res/layout/manage_group_view.xml
+++ b/app/src/main/res/layout/manage_group_view.xml
@@ -57,7 +57,7 @@
             android:layout_width="19dp"
             android:layout_marginStart="20dp"
             android:layout_gravity="center_vertical"
-            android:src="@drawable/ic_plus_sign"/>
+            android:src="@drawable/ic_edit_pencil"/>
 
         <TextView
             android:fontFamily="sans-serif-medium"
@@ -72,36 +72,6 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/endPoll"
-        android:clickable="true"
-        android:focusable="true"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="21dp"
-        android:layout_width="match_parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/editGroupName"
-        tools:ignore="UseCompoundDrawables">
-
-        <ImageView
-            android:layout_height="18dp"
-            android:layout_width="18dp"
-            android:layout_marginStart="20dp"
-            android:layout_gravity="center_vertical"
-            android:src="@drawable/ic_plus_sign" />
-
-        <TextView
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center_vertical"
-            android:layout_marginStart="31dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/end_poll"
-            android:textColor="@color/black"
-            android:textSize="18sp" />
-
-    </LinearLayout>
-
-    <LinearLayout
         android:clickable="true"
         android:focusable="true"
         android:id="@+id/deleteGroup"
@@ -110,7 +80,7 @@
         android:paddingBottom="21dp"
         android:layout_width="match_parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/endPoll"
+        app:layout_constraintTop_toBottomOf="@id/editGroupName"
         tools:ignore="UseCompoundDrawables">
 
         <ImageView
@@ -119,7 +89,7 @@
             android:layout_marginStart="22dp"
             android:layout_gravity="center_vertical"
             android:rotation="180"
-            android:src="@drawable/leave_group_red" />
+            android:src="@drawable/ic_trash_can" />
 
         <TextView
             android:fontFamily="sans-serif-medium"
@@ -146,8 +116,8 @@
         tools:ignore="UseCompoundDrawables">
 
         <ImageView
-            android:layout_height="18dp"
-            android:layout_width="16dp"
+            android:layout_height="22dp"
+            android:layout_width="20dp"
             android:layout_marginStart="20dp"
             android:layout_gravity="center_vertical"
             android:rotation="180"

--- a/app/src/main/res/layout/manage_group_view.xml
+++ b/app/src/main/res/layout/manage_group_view.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:background="@color/white"
     android:layout_alignParentBottom="true"
-    android:layout_height="174dp"
-    android:layout_marginTop="174dp"
+    android:layout_height="wrap_content"
     android:layout_width="match_parent"
     android:visibility="invisible">
 
@@ -37,16 +36,110 @@
         android:background="@color/lightGrayDivider"
         android:id="@+id/divider"
         android:layout_height="0.5dp"
-        android:layout_marginTop="15dp"
+        android:layout_marginTop="20dp"
         android:layout_width="match_parent"
         app:layout_constraintTop_toBottomOf="@id/closeButton" />
 
     <LinearLayout
+        android:id="@+id/editGroupName"
         android:clickable="true"
         android:focusable="true"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="21dp"
+        android:layout_width="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/divider"
+        tools:ignore="UseCompoundDrawables">
+
+
+        <ImageView
+            android:layout_height="19dp"
+            android:layout_width="19dp"
+            android:layout_marginStart="20dp"
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/ic_plus_sign"/>
+
+        <TextView
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center_vertical"
+            android:layout_marginStart="31dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/edit_group_name"
+            android:textColor="@color/black"
+            android:textSize="18sp"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/endPoll"
+        android:clickable="true"
+        android:focusable="true"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="21dp"
+        android:layout_width="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/editGroupName"
+        tools:ignore="UseCompoundDrawables">
+
+        <ImageView
+            android:layout_height="18dp"
+            android:layout_width="18dp"
+            android:layout_marginStart="20dp"
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/ic_plus_sign" />
+
+        <TextView
+            android:fontFamily="sans-serif-medium"
+            android:gravity="center_vertical"
+            android:layout_marginStart="31dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/end_poll"
+            android:textColor="@color/black"
+            android:textSize="18sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:clickable="true"
+        android:focusable="true"
+        android:id="@+id/deleteGroup"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="21dp"
+        android:paddingBottom="21dp"
+        android:layout_width="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/endPoll"
+        tools:ignore="UseCompoundDrawables">
+
+        <ImageView
+            android:layout_height="18dp"
+            android:layout_width="16dp"
+            android:layout_marginStart="22dp"
+            android:layout_gravity="center_vertical"
+            android:rotation="180"
+            android:src="@drawable/leave_group_red" />
+
+        <TextView
+            android:fontFamily="sans-serif-medium"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="31dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/delete_group"
+            android:textColor="@color/red"
+            android:textSize="18sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/leaveGroup"
-        android:layout_height="18dp"
-        android:layout_marginTop="15dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="21dp"
+        android:paddingBottom="21dp"
         android:layout_width="match_parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/divider"
@@ -54,21 +147,22 @@
 
         <ImageView
             android:layout_height="18dp"
+            android:layout_width="16dp"
             android:layout_marginStart="20dp"
-            android:layout_width="19dp"
+            android:layout_gravity="center_vertical"
+            android:rotation="180"
             android:contentDescription="@string/leave_group_content_description"
             android:src="@drawable/leave_group_red" />
 
         <TextView
             android:fontFamily="sans-serif-medium"
-            android:gravity="center_vertical"
-            android:layout_height="match_parent"
-            android:layout_marginStart="10dp"
-            android:layout_marginTop="-2.5dp"
-            android:layout_width="45dp"
-            android:text="@string/leave_text"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="31dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/leave_group"
             android:textColor="@color/red"
-            android:textSize="16sp" />
+            android:textSize="18sp" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,10 +24,14 @@
 
     <string name="joined">Joined</string>
 
-    <string name="leave_group_content_description">Leave Group</string>
-    <string name="leave_text">Leave</string>
-
     <string name="live_indicator">•</string>
+
+<!--Home Screen Edit Group Strings-->
+    <string name="leave_group_content_description">Leave Group</string>
+    <string name="leave_group">Leave</string>
+    <string name="delete_group">Delete Group</string>
+    <string name="edit_group_name">Edit Name</string>
+    <string name="end_poll">End Poll</string>
 
 <!--Home Screen Empty State Strings-->
     <string name="no_groups_joined_emoji">&#129335;&#8205;&#9792;&#65039;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
 
 <!--Home Screen Edit Group Strings-->
     <string name="leave_group_content_description">Leave Group</string>
-    <string name="leave_group">Leave</string>
+    <string name="leave_group">Leave Group</string>
     <string name="delete_group">Delete Group</string>
     <string name="edit_group_name">Edit Name</string>
     <string name="end_poll">End Poll</string>


### PR DESCRIPTION
  ## Overview
A little bit of an awkward stopping point, but I wanted to get this in now to unblock Kevin/Preston and keep this PR from getting bigger.

Basically this fixed the UI for the group options menu, added the instructor side options with networking, and moved the group options menu to `GroupFragment`.

Fyi, I left in some commented code that I plan on reusing or removing in the next PR, will clean it up in that one.

  ## Changes Made
- Migrated listeners/logic for the group options menu to `GroupFragment`
- Added and fixed UI for the group options menu
- Added networking for group leaving/deletion and renaming

  ## Next Steps
- Migrate the bottom bar into `GroupFragment` (will both fix a UI bug and is consistent with the refactor of moving logic from the activity -> fragment)
- Add delegation methods in `MainActivity` for:
   - Dimming the screen when the popup/keyboard comes up
   - Launching the newly created/joined group
- Animating the bottom bar on tab change (old bar goes down, new one comes up)

  ## Related PRs or Issues
- Going to leave the current issue #34 active for the follow up PR
- Add in UI for editing the name of the group (#40)

  ## Screenshots
- I'll add them in the second PR as that will fix a few small UI bugs that are lingering 
