### PR TITLE
Group Sorting and Bug Fixes

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -185,8 +185,11 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
                 }
 
                 groups = getGroupsResponse.data
-                groups.sort()
-                groups.reverse()
+                groups.apply {
+                    sort()
+                    reverse()
+                }
+
                 currentAdapter?.addAll(groups)
                 currentAdapter?.notifyDataSetChanged()
                 setNoGroups()
@@ -363,7 +366,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
 
             if (sortedPolls?.success == false || sortedPolls?.data == null) return@launch
 
-            role?.let { delegate?.startGroupActivity(role!!, groupResponse.data, sortedPolls.data) } ?: return@launch
+            role?.let { delegate?.startGroupActivity(it, groupResponse.data, sortedPolls.data) } ?: return@launch
         }
     }
 
@@ -391,7 +394,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
                     addGroup(groupResponse.data)
                 }
 
-                role?.let { delegate?.startGroupActivity(role!!, groupResponse.data, ArrayList()) } ?: return@launch
+                role?.let { delegate?.startGroupActivity(it, groupResponse.data, ArrayList()) } ?: return@launch
             } else {
                 Log.e("failure","backend response failed to generate code")
                 return@launch

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -185,6 +185,8 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
                 }
 
                 groups = getGroupsResponse.data
+                groups.sort()
+                groups.reverse()
                 currentAdapter?.addAll(groups)
                 currentAdapter?.notifyDataSetChanged()
                 setNoGroups()
@@ -224,8 +226,9 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
         }
     }
 
-    private fun addGroup(group: Group) {
-        groups.add(group)
+
+    fun addGroup(group: Group) {
+        groups.add(0, group)
         currentAdapter?.addAll(groups)
         currentAdapter?.notifyDataSetChanged()
         setNoGroups()

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
@@ -101,6 +101,7 @@ class GroupRecyclerAdapter(
                     timeResult = timeResult.removeRange(timeResult.length - 1, timeResult.length)
                 }
                 view.groupLiveTextView.text = "${group.code}  •  Last live $timeResult ago"
+                view.groupLiveTextView.setTextColor(ContextCompat.getColor(view.context, R.color.settings_detail))
             }
         }
     }

--- a/app/src/main/java/com/cornellappdev/android/pollo/models/Group.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/models/Group.kt
@@ -4,4 +4,17 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class Group(val id: String, val name: String, val code: String, val updatedAt: String?, val isLive: Boolean?) : Parcelable
+data class Group(
+        val id: String,
+        val name: String,
+        val code: String,
+        val updatedAt: String?,
+        val isLive: Boolean?
+) : Parcelable, Comparable<Group> {
+
+    override fun compareTo(other: Group) : Int {
+        val thisLastUpdated = this.updatedAt?.toLongOrNull() ?: return -1
+        val otherLastUpdated = other.updatedAt?.toLongOrNull() ?: return 1
+        return (thisLastUpdated - otherLastUpdated).toInt()
+    }
+}

--- a/app/src/main/java/com/cornellappdev/android/pollo/models/Group.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/models/Group.kt
@@ -8,13 +8,13 @@ data class Group(
         val id: String,
         val name: String,
         val code: String,
-        val updatedAt: String?,
-        val isLive: Boolean?
+        val updatedAt: String,
+        val isLive: Boolean
 ) : Parcelable, Comparable<Group> {
 
     override fun compareTo(other: Group) : Int {
-        val thisLastUpdated = this.updatedAt?.toLongOrNull() ?: return -1
-        val otherLastUpdated = other.updatedAt?.toLongOrNull() ?: return 1
+        val thisLastUpdated = this.updatedAt.toLongOrNull() ?: return -1
+        val otherLastUpdated = other.updatedAt.toLongOrNull() ?: return 1
         return (thisLastUpdated - otherLastUpdated).toInt()
     }
 }


### PR DESCRIPTION
  ## Overview
Sorted groups such that the newest appear first and fixed an issue where old polls would appear with the green color indicating that they're live.

  ## Changes Made
- Sorted groups by date
- Made it so that added groups are added to the top
- Fixed an issue where the reuse of cells could cause old groups to appear in the green color indicating that they are live (this could be seen by adding two new groups when you already have a few, one of the old ones will say "Last live ... ago", but this will appear in green)

  ## Screenshots

  <details>

    <summary>Sorted groups with only live ones live</summary>

![image](https://user-images.githubusercontent.com/35942769/69561551-91384700-0f7b-11ea-9844-f9d90c940201.png)


  </details>
