### PR TITLE
Shading fix in group options menu

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -300,9 +300,14 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
     /**
      * Dims the `GroupFragment` and calls the delegates dim method according to `shouldDim`
      */
-     fun setDim(shouldDim: Boolean) {
-        delegate?.setDim(shouldDim)
+     private fun setDim(shouldDim: Boolean) {
+        delegate?.setDim(shouldDim, this)
 
+        // Don't want to be able to open group views when dimmed
+        setSelfDim(shouldDim)
+    }
+
+    fun setSelfDim(shouldDim: Boolean) {
         // Don't want to be able to open group views when dimmed
         dimView.isClickable = shouldDim
 
@@ -426,7 +431,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
         /**
          * Should dim any parts of the screen outside of `GroupFragment`
          */
-        fun setDim(shouldDim: Boolean)
+        fun setDim(shouldDim: Boolean, groupFragment: GroupFragment)
 
         /**
          * Launches a `PollsDateActivity` for the given group and parameters

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -115,7 +115,12 @@ class MainActivity : AppCompatActivity(), GroupFragment.GroupFragmentDelegate {
         startActivityForResult(signInIntent, LOGIN_REQ_CODE)
     }
 
-    override fun setDim(shouldDim: Boolean) {
+    override fun setDim(shouldDim: Boolean, groupFragment: GroupFragment) {
+        when (groupFragment) {
+            joinedGroupFragment -> createdGroupFragment?.setSelfDim(shouldDim)
+            createdGroupFragment -> joinedGroupFragment?.setSelfDim(shouldDim)
+        }
+
         settingsImageView.isEnabled = !shouldDim
 
         val alphaValue = if (shouldDim) 0.5f else 1.0f


### PR DESCRIPTION
## Overview
Fixed a pretty edge case bug:
 - If you selected the "..." to get the group options menu, the background was shaded
 - If you dismissed this menu by selecting the other tab, the top portion of the screen would un-dim normally, but the new tab would come in fully un-dimmed (see videos)

  ## Changes Made
Dimmed both group fragments when a group option menu is selected (that way the fragment coming in is dimmed and being undimmed the same as the top portion).

  ## Screenshots

 Check #pollo-android for some screen recordings :)
