### PR TITLE
Fixed crash when missing poll type

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsChoiceRecyclerAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsChoiceRecyclerAdapter.kt
@@ -32,6 +32,11 @@ class PollsChoiceRecyclerAdapter(private val poll: Poll,
                 val inflatedView = parent.inflate(R.layout.poll_free_response_item_row, false)
                 FreeResponseHolder(inflatedView)
             }
+
+            null -> {
+                val inflatedView = parent.inflate(R.layout.poll_multiple_choice_item_row, false)
+                ChoiceHolder(inflatedView)
+            }
         }
     }
 
@@ -39,6 +44,7 @@ class PollsChoiceRecyclerAdapter(private val poll: Poll,
         return when (poll.type) {
             PollType.multipleChoice -> 0
             PollType.freeResponse -> 1
+            null -> 0
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsChoiceRecyclerAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsChoiceRecyclerAdapter.kt
@@ -23,7 +23,7 @@ class PollsChoiceRecyclerAdapter(private val poll: Poll,
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (poll.type) {
-            PollType.multipleChoice -> {
+            PollType.multipleChoice, null -> {
                 val inflatedView = parent.inflate(R.layout.poll_multiple_choice_item_row, false)
                 ChoiceHolder(inflatedView)
             }
@@ -32,19 +32,13 @@ class PollsChoiceRecyclerAdapter(private val poll: Poll,
                 val inflatedView = parent.inflate(R.layout.poll_free_response_item_row, false)
                 FreeResponseHolder(inflatedView)
             }
-
-            null -> {
-                val inflatedView = parent.inflate(R.layout.poll_multiple_choice_item_row, false)
-                ChoiceHolder(inflatedView)
-            }
         }
     }
 
     override fun getItemViewType(position: Int): Int {
         return when (poll.type) {
-            PollType.multipleChoice -> 0
+            PollType.multipleChoice, null -> 0
             PollType.freeResponse -> 1
-            null -> 0
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsRecyclerAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsRecyclerAdapter.kt
@@ -66,7 +66,7 @@ class PollsRecyclerAdapter(private var polls: ArrayList<Poll>,
             // height = 1250
         }
 
-        val questionType = poll.type
+        val questionType = poll.type ?: PollType.multipleChoice
         holder.bindPoll(poll, questionType, this)
 
         val childLayoutManager = LinearLayoutManager(holder.view.pollsChoiceRecyclerView.context)

--- a/app/src/main/java/com/cornellappdev/android/pollo/models/Poll.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/models/Poll.kt
@@ -22,5 +22,5 @@ enum class PollState: Parcelable {
 @Parcelize
 data class Poll(val createdAt: String?, val updatedAt: String?, var id: String?,
                 val text: String, val answerChoices: ArrayList<PollResult>,
-                val type: PollType, val correctAnswer: String?, val userAnswers: MutableMap<String, ArrayList<PollChoice>>?,
+                val type: PollType?, val correctAnswer: String?, val userAnswers: MutableMap<String, ArrayList<PollChoice>>?,
                 val state: PollState): Parcelable


### PR DESCRIPTION
  ## Overview
Fixed bug where app would crash when user clicked on a poll without a poll type. 
 
 ## Changes Made
* Made the type field in Poll optional
* Changed code that uses the poll type to handle the null case

  ## Next Steps 
* Remove usages of the free response poll type
* Possibly remove the poll type field in accordance with changes to the API spec
