### PR TITLE
Edit Group Name #40

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -1,7 +1,9 @@
 package com.cornellappdev.android.pollo
 
+import android.animation.LayoutTransition
 import android.animation.ObjectAnimator
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
 import android.graphics.Color
@@ -16,6 +18,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.TranslateAnimation
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -28,6 +31,7 @@ import com.google.gson.reflect.TypeToken
 import kotlinx.android.synthetic.main.fragment_main.*
 import kotlinx.android.synthetic.main.manage_group_view.*
 import kotlinx.android.synthetic.main.manage_group_view.view.*
+import kotlinx.android.synthetic.main.manage_group_view.view.renameGroupDetail
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -110,7 +114,6 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
         groupMenuOptionsView.renameGroupDetail.saveGroupName.setOnClickListener {
             endRenameGroup()
             dismissPopup()
-            // TODO: dismiss popup?
         }
 
         groupMenuOptionsView.removeGroup.setOnClickListener {
@@ -307,6 +310,9 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
         groupSelected = null
 
         if (isNameEditingActive) {
+            // Reset this from beginRenameGroup
+            groupMenuOptionsView.layoutTransition.disableTransitionType(LayoutTransition.CHANGE_DISAPPEARING)
+
             // Don't need to check user role since only an admin could edit name in the first place
             groupMenuOptionsView.renameGroupDetail.visibility = View.GONE
             groupMenuOptionsView.renameGroup.visibility = View.VISIBLE
@@ -314,7 +320,11 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
 
             isNameEditingActive = false
             groupMenuOptionsView.renameGroupDetail.renameGroupEditText.text.clear()
-            // TODO: dismiss keyboard?
+
+            if (context != null && view != null) {
+                val imm = context!!.getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+                imm.hideSoftInputFromWindow(view!!.applicationWindowToken, 0)
+            }
         }
     }
 
@@ -436,6 +446,8 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
     private fun beginRenameGroup() {
         isNameEditingActive = true
 
+        // Disable this so that renameGroup and removeGroup disappear immediately
+        groupMenuOptionsView.layoutTransition.disableTransitionType(LayoutTransition.CHANGE_DISAPPEARING)
         groupMenuOptionsView.renameGroupDetail.visibility = View.VISIBLE
         renameGroup.visibility = View.GONE
         removeGroup.visibility = View.GONE
@@ -443,7 +455,6 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
         groupMenuOptionsView.groupNameTextView.text = "Edit Name"
         groupMenuOptionsView.renameGroupDetail.renameGroupEditText.hint = groupSelected?.name
         groupMenuOptionsView.renameGroupDetail.renameGroupEditText.setSelection(0)
-        // TODO: animations?
     }
 
     /**
@@ -481,7 +492,6 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
                 }
             }
         }
-        // TODO: hide keyboard
     }
 
     companion object {

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -26,6 +26,7 @@ import com.cornellappdev.android.pollo.models.User
 import com.cornellappdev.android.pollo.networking.*
 import com.google.gson.reflect.TypeToken
 import kotlinx.android.synthetic.main.fragment_main.*
+import kotlinx.android.synthetic.main.manage_group_view.*
 import kotlinx.android.synthetic.main.manage_group_view.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -84,13 +85,13 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
 
         when (role) {
             User.Role.MEMBER -> {
-                groupMenuOptionsView.editGroupName.visibility = View.GONE
+                groupMenuOptionsView.renameGroup.visibility = View.GONE
                 groupMenuOptionsView.removeGroup.removeGroupImage.rotation = 180f
                 groupMenuOptionsView.removeGroup.removeGroupImage.setImageResource(R.drawable.leave_group_red)
                 groupMenuOptionsView.removeGroup.removeGroupText.setText(R.string.leave_group)
             }
             User.Role.ADMIN -> {
-                groupMenuOptionsView.editGroupName.visibility = View.VISIBLE
+                groupMenuOptionsView.renameGroup.visibility = View.VISIBLE
                 groupMenuOptionsView.removeGroup.removeGroupImage.setImageResource(R.drawable.ic_trash_can)
                 groupMenuOptionsView.removeGroup.removeGroupText.setText(R.string.delete_group)
             }
@@ -101,8 +102,13 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
             dismissPopup()
         }
 
-        groupMenuOptionsView.editGroupName.setOnClickListener {
-            // TODO(#40)
+        groupMenuOptionsView.renameGroup.setOnClickListener {
+            beginRenameGroup()
+        }
+
+        groupMenuOptionsView.renameGroupDetail.saveGroupName.setOnClickListener {
+            endRenameGroup() // passing a boolean?
+            // TODO: dismiss popup?
         }
 
         groupMenuOptionsView.removeGroup.setOnClickListener {
@@ -331,7 +337,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
 
-            var canProceed = when (role) {
+            val canProceed = when (role) {
                 User.Role.MEMBER -> s?.length == 6
                 User.Role.ADMIN -> s?.length != 0
                 null -> return
@@ -409,6 +415,67 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
                 return@launch
             }
         }
+    }
+
+    /**
+     * Shows keyboard and renaming `EditText` in the group options menu
+     */
+    private fun beginRenameGroup() {
+
+
+        groupMenuOptionsView.renameGroupDetail.visibility = View.VISIBLE
+        renameGroup.visibility = View.GONE
+        removeGroup.visibility = View.GONE
+
+        groupMenuOptionsView.groupNameTextView.text = "Edit Name"
+        groupMenuOptionsView.renameGroupDetail.renameGroupEditText.hint = groupSelected?.name
+        groupMenuOptionsView.renameGroupDetail.renameGroupEditText.setSelection(0)
+
+
+//        var alertDialog = AlertDialog.Builder(context)
+//
+//        alertDialog.apply {
+//            setTitle("Edit Name")
+//
+//            val editText = EditText(context)
+//
+//            editText.apply {
+//                hint = groupSelected?.name
+//
+//                setPadding(40,0,40,0)
+//
+//                setBackgroundResource(R.drawable.rounded_container)
+//            }
+//
+//            setView(editText)
+//
+//            setPositiveButton("Save") { d, _ ->
+//                val newName = editText.text.toString()
+//                newName.removePrefix(" ")
+//                if (newName == "") return@setPositiveButton
+//
+//                println("set new name")
+//                d.cancel()
+//                dismissPopup()
+//            }
+//
+//            setNegativeButton("Cancel") { d, _ ->
+//                d.cancel()
+//                dismissPopup()
+//            }
+//
+//        }
+//
+//        alertDialog.show()
+    }
+
+    /**
+     * Resets the group options menu to its default state (edit/delete group options for admins) and
+     * renames group (locally and to beckend). Does not dismiss the group options menu.
+     */
+    private fun endRenameGroup(){
+
+        // TODO
     }
 
     companion object {

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
@@ -111,6 +111,11 @@ class GroupRecyclerAdapter(
         groups.addAll(newList)
     }
 
+    fun updateGroup(group: Group, index: Int) {
+        groups[index] = group
+        notifyItemChanged(index)
+    }
+
     internal fun getItem(index: Int): Group {
         return groups[index]
     }

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
@@ -92,9 +92,12 @@ class GroupRecyclerAdapter(
                 val lastUpdated = java.lang.Long.parseLong(group.updatedAt)
                 var timeResult = " "
                 val timeSplit = Util.splitToComponentTimes(unixTime - lastUpdated)
-                for (i in 0..6) {
+                for (i in TIME_LABELS.indices) {
                     timeResult = timeSplit[i].toString() + " " + TIME_LABELS[i]
-                    if (timeSplit[i] != 0) break
+                    if (timeSplit[i] > 0) break
+
+                    // To handle issue where `group.updatedAt` is greater than the current time
+                    if (i == TIME_LABELS.size-1) timeResult = "1 " + TIME_LABELS[i]
                 }
 
                 if (timeResult[0] == '1') {

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/Endpoint.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/Endpoint.kt
@@ -44,6 +44,14 @@ class Endpoint(private val path: String, private val headers: Map<String, String
                         .build()
             }
 
+            EndpointMethod.PUT -> {
+                return Request.Builder()
+                        .url(endpoint)
+                        .headers(headers)
+                        .put(body ?: RequestBody.create(MediaType.get("application/json; charset=utf-8"), ""))
+                        .build()
+            }
+
             else -> {
                 throw IllegalArgumentException("NOT IMPLEMENTED")
             }

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/GroupEndpoints.kt
@@ -26,7 +26,7 @@ fun Endpoint.Companion.deleteGroup(id: String): Endpoint {
     return Endpoint("/sessions/$id", headers = mapOf("Authorization" to "Bearer ${User.currentSession.accessToken}"), method = EndpointMethod.DELETE)
 }
 
-fun Endpoint.Companion.renameGroup(id: Int, name: String): Endpoint {
+fun Endpoint.Companion.renameGroup(id: String, name: String): Endpoint {
     val nameJSON = JSONObject()
     nameJSON.put("name", name)
     val requestBody = RequestBody.create(MediaType.get("application/json; charset=utf-8"), nameJSON.toString())

--- a/app/src/main/res/drawable-mdpi/rounded_grey_border.xml
+++ b/app/src/main/res/drawable-mdpi/rounded_grey_border.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke
+        android:width="2dp"
+        android:color="@color/lightGray"/>
+    <corners
+        android:bottomRightRadius="3dp"
+        android:bottomLeftRadius="3dp"
+        android:topLeftRadius="3dp"
+        android:topRightRadius="3dp"/>
+</shape>

--- a/app/src/main/res/drawable/rounded_save_rename_button.xml
+++ b/app/src/main/res/drawable/rounded_save_rename_button.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  res/drawable/rounded_edittext.xml -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" android:padding="10dp">
+    <solid android:color="@color/polloGreen"/>
+    <corners
+        android:bottomRightRadius="25dp"
+        android:bottomLeftRadius="25dp"
+        android:topLeftRadius="25dp"
+        android:topRightRadius="25dp"/>
+</shape>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -126,9 +126,7 @@
 </androidx.constraintlayout.widget.ConstraintLayout>
     <include
         layout="@layout/manage_group_view"
-        android:id="@+id/groupMenuOptionsView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignBottom="@id/constraintLayout" />
-
 </RelativeLayout>

--- a/app/src/main/res/layout/manage_group_view.xml
+++ b/app/src/main/res/layout/manage_group_view.xml
@@ -41,7 +41,7 @@
         app:layout_constraintTop_toBottomOf="@id/closeButton" />
 
     <LinearLayout
-        android:id="@+id/editGroupName"
+        android:id="@+id/renameGroup"
         android:clickable="true"
         android:focusable="true"
         android:layout_height="wrap_content"
@@ -80,7 +80,7 @@
         android:paddingBottom="21dp"
         android:layout_width="match_parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/editGroupName"
+        app:layout_constraintTop_toBottomOf="@id/renameGroup"
         tools:ignore="UseCompoundDrawables">
 
         <ImageView
@@ -102,4 +102,39 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/renameGroupDetail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:orientation="vertical"
+
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/divider">
+
+        <EditText
+            android:id="@+id/renameGroupEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:layout_marginStart="25dp"
+            android:layout_marginEnd="25dp"
+            android:layout_marginTop="25dp"
+            android:layout_marginBottom="25dp"
+            android:padding="15dp"
+            android:background="@drawable/rounded_grey_border"
+            />
+
+        <Button
+            android:id="@+id/saveGroupName"
+            android:layout_width="200dp"
+            android:layout_height="50dp"
+            android:layout_gravity="center"
+            android:text="@string/save_group_name"
+            android:textColor="@color/actualWhite"
+            android:layout_marginBottom="50dp"
+            android:background="@drawable/rounded_save_rename_button"
+            />
+    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/manage_group_view.xml
+++ b/app/src/main/res/layout/manage_group_view.xml
@@ -120,6 +120,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textSize="16sp"
+            android:inputType="text"
+            android:hint=""
             android:layout_marginStart="25dp"
             android:layout_marginEnd="25dp"
             android:layout_marginTop="25dp"

--- a/app/src/main/res/layout/manage_group_view.xml
+++ b/app/src/main/res/layout/manage_group_view.xml
@@ -2,22 +2,24 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/groupMenuOptionsView"
     android:background="@color/white"
     android:layout_alignParentBottom="true"
     android:layout_height="wrap_content"
     android:layout_width="match_parent"
-    android:visibility="invisible">
+    android:visibility="invisible"
+    android:animateLayoutChanges="true">
 
     <TextView
         android:id="@+id/groupNameTextView"
         android:fontFamily="sans-serif-medium"
-        android:layout_height="25dp"
+        android:layout_height="30dp"
         android:layout_marginStart="22dp"
-        android:layout_marginTop="15dp"
+        android:layout_marginTop="20dp"
         android:layout_width="wrap_content"
         android:text=""
         android:textColor="@color/black"
-        android:textSize="17sp"
+        android:textSize="18sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,6 @@
     <string name="leave_group">Leave Group</string>
     <string name="delete_group">Delete Group</string>
     <string name="edit_group_name">Edit Name</string>
-    <string name="end_poll">End Poll</string>
     <string name="save_group_name">Save</string>
 
 <!--Home Screen Empty State Strings-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="delete_group">Delete Group</string>
     <string name="edit_group_name">Edit Name</string>
     <string name="end_poll">End Poll</string>
+    <string name="save_group_name">Save</string>
 
 <!--Home Screen Empty State Strings-->
     <string name="no_groups_joined_emoji">&#129335;&#8205;&#9792;&#65039;</string>


### PR DESCRIPTION
 ## Overview

Added functionality to allow admins to rename their groups. Done from the home screen by pressing the 'more' button for a given group

  ## Changes Made

 - Added necessary UI elements
 - Added networking for renaming
 - Added logic to allow for renaming in the group options menu (the thing that pops up when the 'more' button is selected), reseting to its normal state once renaming is done

  ## Test Coverage

 - Tested on Pixel 3a XL @API 28 emulator


  ## Related PRs or Issues

#40 

  ## Screenshots

See #pollo-android
