### PR TITLE
Disabled Crashlytics for debug build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,13 @@ android {
         buildConfigField("String", "BACKEND_URI", "\"pollo-dev.cornellappdev.com\"")
     }
     buildTypes {
+        debug {
+            manifestPlaceholders = [crashlyticsCollectionEnabled:"false"]
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
         release {
+            manifestPlaceholders = [crashlyticsCollectionEnabled:"true"]
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,9 @@
         <activity
             android:name=".polls.PollsActivity"
             android:theme="@style/AppTheme.NoActionBar" />
+        <meta-data
+            android:name="firebase_crashlytics_collection_enabled"
+            android:value="${crashlyticsCollectionEnabled}" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -19,7 +19,6 @@ import com.cornellappdev.android.pollo.networking.*
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.gson.reflect.TypeToken
 import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.fragment_main.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch


### PR DESCRIPTION
  ## Overview

 - Disabled Crashlytics for debug builds--now our crashes during development won't be lumped in with any crashes in our released app

