### PR TITLE
debug delete draft and draft layout xml

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/CreatePollFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/CreatePollFragment.kt
@@ -1,17 +1,24 @@
 package com.cornellappdev.android.pollo
 
+import android.animation.LayoutTransition
+import android.animation.ObjectAnimator
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.TranslateAnimation
 import android.view.inputmethod.InputMethodManager
 import android.widget.Button
+import android.widget.TextView
 import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.getColor
 import androidx.fragment.app.Fragment
 import com.cornellappdev.android.pollo.models.*
 import com.cornellappdev.android.pollo.models.PollResult
@@ -22,15 +29,21 @@ import kotlinx.android.synthetic.main.create_poll_onboarding.view.*
 import kotlinx.android.synthetic.main.create_poll_options_list_item.view.*
 import kotlinx.android.synthetic.main.fragment_create_poll.*
 import kotlinx.android.synthetic.main.fragment_create_poll.view.*
+import kotlinx.android.synthetic.main.fragment_create_poll.view.groupNameTextView
+import kotlinx.android.synthetic.main.fragment_main.*
+import kotlinx.android.synthetic.main.manage_group_view.*
+import kotlinx.android.synthetic.main.manage_group_view.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @SuppressLint("ValidFragment")
-class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate {
+class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate, DraftAdapter.OnDraftOptionsPressedListener {
     var options: ArrayList<String> = arrayListOf()
     var createPollAdapter: CreatePollAdapter? = null
+    private var delegate: CreatePollDelegate? = null
+    private var isPopupActive: Boolean = false
     var drafts: ArrayList<Draft> = arrayListOf()
     var draftAdapter: DraftAdapter? = null
     var selectedDraft: Draft? = null
@@ -84,6 +97,7 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate {
             preferencesHelper.displayOnboarding = false
         }
 
+
         return rootView
     }
 
@@ -104,6 +118,14 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setDraftsHeader()
+        // Setup options menu for drafts
+        groupMenuOptionsView.renameGroup.visibility = View.GONE
+
+        groupMenuOptionsView.closeButton.setOnClickListener {
+            dismissPopup()
+        }
+
+
     }
 
     /**
@@ -112,7 +134,7 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate {
     private fun startPoll(correct: Int) {
         if (selectedDraft != null) {
             for (i in 0 until drafts.size) {
-                if (drafts[i].id == selectedDraft!!.id){
+                if (drafts[i].id == selectedDraft!!.id) {
                     draftDeleted(i)
                     break
                 }
@@ -291,7 +313,7 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate {
 
     // ONBOARDING
 
-    private fun setupOnboard(view : View) {
+    private fun setupOnboard(view: View) {
         currOnboardScreen = 0
 
         view.onboardingView.visibility = View.VISIBLE
@@ -310,14 +332,14 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate {
         outlineBubble(view.bubble_outline2)
     }
 
-    private fun outlinePollOption(view : View, text : String) {
+    private fun outlinePollOption(view: View, text: String) {
         outlineBubble(view)
         view.setBackgroundResource(R.drawable.rounded_container_outline)
         view.create_poll_options_text.setHintTextColor(Color.WHITE)
         view.create_poll_options_text.hint = text
     }
 
-    private fun outlineBubble(view : View) {
+    private fun outlineBubble(view: View) {
         view.setBackgroundColor(Color.TRANSPARENT)
         view.create_poll_options_text.setHintTextColor(Color.TRANSPARENT)
         view.create_poll_options_item.buttonTintList = ColorStateList.valueOf(Color.WHITE)
@@ -326,7 +348,7 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate {
     /**
      * Moves through onboarding screens
      */
-    private fun displayOnboard(view : ConstraintLayout) {
+    private fun displayOnboard(view: ConstraintLayout) {
         view.getChildAt(currOnboardScreen).visibility = View.GONE
         currOnboardScreen++
         if (currOnboardScreen < view.childCount) {
@@ -337,4 +359,77 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate {
             footerView.elevation = 4f
         }
     }
+
+    fun dismissPopup() {
+        if (!isPopupActive) return
+        isPopupActive = false
+        setDim(false)
+        val animate = TranslateAnimation(0f, 0f, 0f, groupMenuOptionsView.height.toFloat())
+        animate.duration = 300
+        animate.fillAfter = true
+        groupMenuOptionsView.startAnimation(animate)
+        groupMenuOptionsView.visibility = View.GONE
+        groupMenuOptionsView.removeGroup.visibility = View.GONE
+
+        if (animate.hasEnded()) {
+
+            headerView.elevation = 4f
+            footerView.elevation = 4f
+        }
+
+
+    }
+
+
+    override fun OnDraftOptionsPressed(position: Int) {
+        if (isPopupActive) return
+        isPopupActive = true
+        setDim(true)
+        groupMenuOptionsView.removeGroup.visibility = View.VISIBLE
+        groupMenuOptionsView.groupNameTextView.text = "Draft Options"
+        groupMenuOptionsView.removeGroup.removeGroupImage.setImageResource(R.drawable.ic_trash_can)
+        groupMenuOptionsView.removeGroup.removeGroupText.setText(R.string.delete_poll)
+        headerView.elevation = 0f
+        footerView.elevation = 0f
+        groupMenuOptionsView.visibility = View.VISIBLE
+
+        val animate = TranslateAnimation(0f, 0f, groupMenuOptionsView.height.toFloat(), 0f)
+        animate.duration = 300
+        animate.fillAfter = true
+        groupMenuOptionsView.startAnimation(animate)
+        groupMenuOptionsView.removeGroup.setOnClickListener {
+            // Reset selection
+            draftAdapter!!.resetSelection(position)
+
+            dismissPopup()
+
+        }
+    }
+
+    private fun setDim(shouldDim: Boolean) {
+        delegate?.setDim(shouldDim, this)
+        // Don't want to be able to open poll views when dimmed
+
+        setSelfDim(shouldDim)
+    }
+
+    fun setSelfDim(shouldDim: Boolean) {
+        // Don't want to be able to open poll views when dimmed
+        dimView_draft.isClickable = shouldDim
+
+        val alphaValue = if (shouldDim) 0.5f else 0.0f
+        val dimAnimation = ObjectAnimator.ofFloat(dimView_draft, "alpha", alphaValue)
+        dimAnimation.duration = 500
+        dimAnimation.start()
+    }
+
+    interface CreatePollDelegate {
+        /**
+         * Should dim any parts of the screen outside of `CreatePollFragment`
+         */
+        fun setDim(shouldDim: Boolean, createPollFragment: CreatePollFragment)
+
+    }
+
+
 }

--- a/app/src/main/java/com/cornellappdev/android/pollo/CreatePollFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/CreatePollFragment.kt
@@ -121,11 +121,7 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate, DraftAdapter
         // Setup options menu for drafts
         groupMenuOptionsView.renameGroup.visibility = View.GONE
 
-        groupMenuOptionsView.closeButton.setOnClickListener {
-            dismissPopup()
-        }
-
-
+        groupMenuOptionsView.closeButton.setOnClickListener { dismissPopup() }
     }
 
     /**
@@ -381,12 +377,12 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate, DraftAdapter
     }
 
 
-    override fun OnDraftOptionsPressed(position: Int) {
+    override fun onDraftOptionsPressed(position: Int) {
         if (isPopupActive) return
         isPopupActive = true
         setDim(true)
         groupMenuOptionsView.removeGroup.visibility = View.VISIBLE
-        groupMenuOptionsView.groupNameTextView.text = "Draft Options"
+        groupMenuOptionsView.groupNameTextView.text = getString(R.string.draft_options)
         groupMenuOptionsView.removeGroup.removeGroupImage.setImageResource(R.drawable.ic_trash_can)
         groupMenuOptionsView.removeGroup.removeGroupText.setText(R.string.delete_poll)
         headerView.elevation = 0f
@@ -400,9 +396,7 @@ class CreatePollFragment : Fragment(), DraftAdapter.DraftsDelegate, DraftAdapter
         groupMenuOptionsView.removeGroup.setOnClickListener {
             // Reset selection
             draftAdapter!!.resetSelection(position)
-
             dismissPopup()
-
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/DraftsAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/DraftsAdapter.kt
@@ -9,16 +9,19 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.*
 import androidx.core.content.ContextCompat
 import com.cornellappdev.android.pollo.models.Draft
+import com.cornellappdev.android.pollo.models.Group
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.SnackbarContentLayout
 import kotlinx.android.synthetic.main.draft_list_item.view.*
 
 class DraftAdapter(private val context: Context,
                    private var drafts: ArrayList<Draft>,
-                   private var root: CreatePollFragment) :
+                   val callback: OnDraftOptionsPressedListener
+) :
         BaseAdapter() {
 
     var delegate: DraftsDelegate? = null
+
     private val inflater: LayoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
     private var selectedDraftItem: View? = null // draft_list_item that is currently selected
 
@@ -47,7 +50,8 @@ class DraftAdapter(private val context: Context,
         }
 
         rowView.draftOptionsButton.setOnClickListener {
-            draftOptionsSelected(rowView, position)
+            callback.OnDraftOptionsPressed(position)
+            //draftOptionsSelected(rowView, position)
         }
 
         return rowView
@@ -105,36 +109,31 @@ class DraftAdapter(private val context: Context,
         view?.findViewById<TextView>(R.id.questionTypeTextView)?.setTextColor(color)
     }
 
-    private fun draftOptionsSelected(view: View, position: Int) {
-        val snackBar = Snackbar.make(view, R.string.delete_poll, Snackbar.LENGTH_LONG)
-
-        val textView = snackBar.view.findViewById(R.id.snackbar_action) as TextView
-        val deleteImage = ImageView(context)
-        deleteImage.scaleType = ImageView.ScaleType.CENTER_INSIDE
-        deleteImage.scaleY = .6f
-        deleteImage.scaleX = .6f
-        deleteImage.setImageResource(R.drawable.ic_trash_can)
-        val layoutImageParams = ViewGroup.LayoutParams(WRAP_CONTENT, MATCH_PARENT)
-        (textView.parent as SnackbarContentLayout).addView(deleteImage, layoutImageParams)
-        deleteImage.setOnClickListener {
-            if (selectedDraftItem != null) {
-                // Reset selection
-                setDraftItemSelection(selectedDraftItem, SelectionAction.Deselect)
-                delegate?.draftDeselected()
-            }
-            delegate?.draftDeleted(position)
-            snackBar.dismiss()
-        }
-        snackBar.show()
-    }
 
     private enum class SelectionAction {
         Select, Deselect
+    }
+
+
+    fun resetSelection(position: Int) {
+        if (selectedDraftItem != null) {
+            // Reset selection
+            setDraftItemSelection(selectedDraftItem, SelectionAction.Deselect)
+            //clear draft text and options
+            delegate?.draftDeselected()
+        }
+        delegate?.draftDeleted(position)
+
     }
 
     interface DraftsDelegate {
         fun draftSelected(draft: Draft) // Populates draft creation fields appropriately
         fun draftDeselected()   // Clears draft creation fields
         fun draftDeleted(position: Int)
+
+    }
+
+    interface OnDraftOptionsPressedListener {
+        fun OnDraftOptionsPressed(position: Int)
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/pollo/DraftsAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/DraftsAdapter.kt
@@ -50,8 +50,7 @@ class DraftAdapter(private val context: Context,
         }
 
         rowView.draftOptionsButton.setOnClickListener {
-            callback.OnDraftOptionsPressed(position)
-            //draftOptionsSelected(rowView, position)
+            callback.onDraftOptionsPressed(position)
         }
 
         return rowView
@@ -134,6 +133,6 @@ class DraftAdapter(private val context: Context,
     }
 
     interface OnDraftOptionsPressedListener {
-        fun OnDraftOptionsPressed(position: Int)
+        fun onDraftOptionsPressed(position: Int)
     }
 }

--- a/app/src/main/res/layout/fragment_create_poll.xml
+++ b/app/src/main/res/layout/fragment_create_poll.xml
@@ -44,90 +44,95 @@
     </RelativeLayout>
 
 
-    <RelativeLayout
-        android:id="@+id/createPollView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/headerView">
-
-        <EditText
-            android:id="@+id/poll_question"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentEnd="true"
-            android:layout_marginStart="24dp"
-            android:layout_marginTop="12dp"
-            android:layout_marginEnd="24dp"
-            android:background="@android:color/transparent"
-            android:hint="@string/ask_question" />
-
-        <ListView
-            android:id="@+id/poll_options"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/poll_question"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentEnd="true"
-            android:layout_marginStart="24dp"
-            android:layout_marginTop="12dp"
-            android:layout_marginEnd="24dp"
-            android:divider="@android:color/transparent"
-            android:dividerHeight="8dp" />
-
-        <Button
-            android:id="@+id/add_poll_option_button"
-            android:layout_width="wrap_content"
-            android:layout_height="60dp"
-            android:layout_below="@+id/poll_options"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentEnd="true"
-            android:layout_marginStart="24dp"
-            android:layout_marginTop="2dp"
-            android:layout_marginEnd="24dp"
-            android:backgroundTint="@color/cardHeaderGray"
-            android:drawableLeft="@drawable/plus_sign_grey"
-            android:elevation="4dp"
-            android:text="@string/add_option"
-            android:textAlignment="textStart"
-            android:textAllCaps="false"
-            android:textColor="@color/settings_detail"
-            android:textSize="18sp" />
-
-    </RelativeLayout>
-    
     <LinearLayout
-        android:id="@+id/drafts"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:orientation="vertical"
-        android:layout_below="@id/createPollView"
-        >
-        
-        <TextView
-            android:id="@+id/draftsHeader"
-            android:layout_width="match_parent"
-            android:layout_height="26dp"
-            android:textColor="@color/black"
-            android:textStyle="bold"
-            android:textAlignment="center"
-            android:visibility="gone"
-            />
+        android:layout_above="@id/footerView"
+        android:layout_below="@id/headerView"
+        android:orientation="vertical">
 
-        <ListView
-            android:id="@+id/draftsListView"
+        <RelativeLayout
+            android:id="@+id/createPollView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <EditText
+                android:id="@+id/poll_question"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginStart="24dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="24dp"
+                android:background="@android:color/transparent"
+                android:hint="@string/ask_question" />
+
+            <ListView
+                android:id="@+id/poll_options"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/poll_question"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginStart="24dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginEnd="24dp"
+                android:divider="@android:color/transparent"
+                android:dividerHeight="8dp" />
+
+            <Button
+                android:id="@+id/add_poll_option_button"
+                android:layout_width="wrap_content"
+                android:layout_height="60dp"
+                android:layout_below="@+id/poll_options"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentEnd="true"
+                android:layout_marginStart="24dp"
+                android:layout_marginTop="2dp"
+                android:layout_marginEnd="24dp"
+                android:backgroundTint="@color/cardHeaderGray"
+                android:drawableLeft="@drawable/plus_sign_grey"
+                android:elevation="4dp"
+                android:text="@string/add_option"
+                android:textAlignment="textStart"
+                android:textAllCaps="false"
+                android:textColor="@color/settings_detail"
+                android:textSize="18sp" />
+
+        </RelativeLayout>
+
+        <LinearLayout
+            android:id="@+id/drafts"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp"
-            android:layout_marginTop="6dp"
-            android:scrollbars="none"
-            android:divider="@android:color/transparent"
-            android:dividerHeight="12dp"/>
-        
-        
+            android:layout_below="@id/createPollView"
+            android:layout_marginTop="20dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/draftsHeader"
+                android:layout_width="match_parent"
+                android:layout_height="26dp"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textStyle="bold"
+                android:visibility="gone" />
+
+            <ListView
+                android:id="@+id/draftsListView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="6dp"
+                android:layout_marginEnd="20dp"
+                android:divider="@android:color/transparent"
+                android:dividerHeight="12dp"
+                android:scrollbars="none" />
+
+
+        </LinearLayout>
     </LinearLayout>
 
     <LinearLayout
@@ -193,10 +198,23 @@
 
     </LinearLayout>
 
+    <View
+        android:id="@+id/dimView_draft"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:alpha="0.0"
+        android:background="@color/black" />
+
     <include
         android:id="@+id/onboardingView"
         layout="@layout/create_poll_onboarding"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="gone" />
+
+    <include
+        layout="@layout/manage_group_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true" />
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_create_poll.xml
+++ b/app/src/main/res/layout/fragment_create_poll.xml
@@ -107,7 +107,6 @@
             android:id="@+id/drafts"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/createPollView"
             android:layout_marginTop="20dp"
             android:orientation="vertical">
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="untitled_poll">Untitled Poll</string>
     <string name="multiple_choice">Multiple Choice</string>
     <string name="save_as_draft">Save as Draft</string>
+    <string name="draft_options">Draft Options</string>
     <string name="start_poll">Start Question</string>
 
     <!-- Poll Options -->


### PR DESCRIPTION




  ## Overview


Worked on a bottom option bar for deleting draft instead of a snack bar.
An additional bug that got fixed is that the draft view would get covered by the footerview in the createPoll xml when there are too many.



  ## Changes Made

  <!-- Include details of what your changes actually are and how it is intended to work. -->
Uses GroupMenuOptionView instead of snackbar to represent delete draft option menu. 
Dim the createPollFragment when the OptionView is on.
Instead of dismiss snackbar added a dismissPopup function to delete the OptionView in CreatePollFragment
I notice that in the original version, if there are too many drafts in the listview, part of the draft in the bottom will be covered behind the footerview in createPollFragment. 
So I added a linearlayout that include both the createPollView and the drafts and constraint it to be above the footerview

  ## Test Coverage
I manually tested with the emulator. Basically 3 tests.
1. Save a draft and delete it
2. Save a draft select it and delete it (to see if the createPollView will reset)
3. Save a lot of drafts and see if part of the drafts are hidden




  ## Related PRs or Issues (delete if not applicable)
There are just a few parts I am not sure about
1. select save as draft when there is a draft selected, it will just unselect the selected draft, it works as it is coded but I am not sure if it makes sense for users. Ignore me if it does, I was just a bit confused when I tested it. 
2. delete options: there seems to only have add options, but no delete options. 
3. scrollable for the whole view? or just draft part? It seems like when we have a lot of options there is just no place for draft, so do we need to have a scrollable view as a whole? 
Or maybe no crazy professor will need that many options can we just hind the add option button after a specific number of options



