### PR TITLE
Fix inconsistent poll counts and various bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.cornellappdev.android.pollo"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        versionCode 7
+        versionName "1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "web_client_id", keyProperties['web_client_id'])
         buildConfigField("String", "BACKEND_URI", "\"pollo-dev.cornellappdev.com\"")
@@ -62,7 +62,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth:19.4.0'
     implementation 'com.google.android.gms:play-services-auth:18.1.0'
     implementation 'com.google.firebase:firebase-crashlytics:17.2.2'
-    implementation 'com.google.firebase:firebase-analytics:17.5.0'
+    implementation 'com.google.firebase:firebase-analytics:17.6.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.squareup.okhttp3:okhttp:3.13.1'
     implementation 'com.squareup.okio:okio:2.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "com.cornellappdev.android.pollo"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 7
+        versionCode 8
         versionName "1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "web_client_id", keyProperties['web_client_id'])
@@ -72,6 +72,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'androidx.fragment:fragment-ktx:1.2.5'
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,13 +21,13 @@ android {
     }
     buildTypes {
         debug {
-            manifestPlaceholders = [crashlyticsCollectionEnabled:"false"]
+            manifestPlaceholders = [crashlyticsCollectionEnabled: "false"]
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField("boolean", "DUMMY_LOGIN_ENABLED", "true")
         }
         release {
-            manifestPlaceholders = [crashlyticsCollectionEnabled:"true"]
+            manifestPlaceholders = [crashlyticsCollectionEnabled: "true"]
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField("boolean", "DUMMY_LOGIN_ENABLED", "false")

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -313,7 +313,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
         if (isPopupActive) return
         isPopupActive = true
         setDim(true)
-        dimView.setOnClickListener{
+        dimView.setOnClickListener {
             dismissPopup()
         }
         groupSelected = group
@@ -358,7 +358,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
     /**
      * Dims the `GroupFragment` and calls the delegates dim method according to `shouldDim`
      */
-     private fun setDim(shouldDim: Boolean) {
+    private fun setDim(shouldDim: Boolean) {
         delegate?.setDim(shouldDim, this)
 
         // Don't want to be able to open group views when dimmed
@@ -493,7 +493,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
      * Resets the group options menu to its default state (edit/delete group options for admins) and
      * renames group (locally and to backend). Does not dismiss the group options menu.
      */
-    private fun finishRenameGroup(){
+    private fun finishRenameGroup() {
         val newGroupName = renameGroupEditText.text.toString().trim()
         if (newGroupName == "" || groupSelected == null) {
             AlertDialog.Builder(context)

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.text.Editable
 import android.text.InputFilter
+import android.text.InputType
 import android.text.TextWatcher
 import android.util.Log
 import android.view.KeyEvent
@@ -81,6 +82,10 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        swipeRefresh.setOnRefreshListener {
+            refreshGroups()
+        }
 
         setNoGroups()
         dimView.bringToFront()
@@ -155,6 +160,8 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
             User.Role.MEMBER -> {
                 addGroupEditText.setHint(R.string.join_group_hint)
                 addGroupEditText.setTextColor(Color.WHITE)
+                addGroupEditText.isAllCaps = true
+                addGroupEditText.inputType = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS
                 addGroupEditText.filters = addGroupEditText.filters +
                         InputFilter.AllCaps() +
                         InputFilter.LengthFilter(6) +
@@ -224,6 +231,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
                 currentAdapter?.addAll(groups)
                 currentAdapter?.notifyDataSetChanged()
                 setNoGroups()
+                swipeRefresh?.isRefreshing = false
             }
         }
     }
@@ -305,6 +313,9 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
         if (isPopupActive) return
         isPopupActive = true
         setDim(true)
+        dimView.setOnClickListener{
+            dismissPopup()
+        }
         groupSelected = group
         groupMenuOptionsView.groupNameTextView.text = group?.name ?: "Pollo Group"
         groupMenuOptionsView.visibility = View.VISIBLE

--- a/app/src/main/java/com/cornellappdev/android/pollo/LoginActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/LoginActivity.kt
@@ -41,6 +41,7 @@ class LoginActivity : AppCompatActivity() {
         val cookieManager = CookieManager.getInstance()
         cookieManager.removeAllCookies(null)
         sso_button.setOnClickListener {
+            WebView.setWebContentsDebuggingEnabled(false)
             webview.settings.javaScriptEnabled = true
             webview.addJavascriptInterface(WebAppInterface(this), "Mobile")
             webview.webViewClient = WebAppClient()

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -93,6 +93,15 @@ class MainActivity : AppCompatActivity(), GroupFragment.GroupFragmentDelegate {
         }
     }
 
+    override fun onBackPressed() {
+        if (appbar.alpha < 1.0f) {
+            joinedGroupFragment?.dismissPopup()
+            createdGroupFragment?.dismissPopup()
+        } else {
+            super.onBackPressed()
+        }
+    }
+
     override fun setDim(shouldDim: Boolean, groupFragment: GroupFragment) {
         when (groupFragment) {
             joinedGroupFragment -> createdGroupFragment?.setSelfDim(shouldDim)

--- a/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsActivity.kt
@@ -110,7 +110,7 @@ class PollsActivity : AppCompatActivity(), SocketDelegate, PollsRecyclerAdapter.
         runOnUiThread {
             adapter.notifyItemChanged(polls.size - 1)
             linearLayoutManager.scrollToPosition(polls.size - 1)
-            currentPollView.text = "${linearLayoutManager.findFirstCompletelyVisibleItemPosition() + 1} / ${polls.size}"
+            currentPollView.text = "${polls.size} / ${polls.size}"
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsChoiceRecyclerAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsChoiceRecyclerAdapter.kt
@@ -58,7 +58,9 @@ class PollsChoiceRecyclerAdapter(private val poll: Poll,
 
         fun bindPoll(poll: Poll, googleId: String, role: User.Role) {
             this.poll = poll
-            this.totalNumberOfResponses = poll.userAnswers.count()
+            this.totalNumberOfResponses = poll.answerChoices.fold(0, { acc, i ->
+                acc + (i.count ?: 0)
+            })
 
             if (role == User.Role.MEMBER && poll.state != PollState.shared) {
                 // hides responses

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/Socket.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/Socket.kt
@@ -89,7 +89,7 @@ object Socket {
         if (args.isEmpty()) return@Listener
         val json = args[0] as JSONObject
         val poll = Gson().fromJson<Poll>(json.toString(), Poll::class.java)
-        delegates.forEach { it.onPollResult(poll) }
+        delegates.forEach { it.onPollUpdateAdmin(poll) }
     }
 
     private val onPollEndAdmin = Emitter.Listener { args ->
@@ -153,6 +153,7 @@ object Socket {
     }
 
     fun deleteSavedPoll(poll: Poll) {
+        onPollDelete.call(poll.id)
         socket.emit("server/poll/delete", poll.id ?: "")
     }
 

--- a/app/src/main/res/drawable/arrow_back.xml
+++ b/app/src/main/res/drawable/arrow_back.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
-</vector>

--- a/app/src/main/res/drawable/arrow_back_small.xml
+++ b/app/src/main/res/drawable/arrow_back_small.xml
@@ -1,5 +1,0 @@
-<vector android:height="14dp" android:tint="#FFFFFF"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="14dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
-</vector>

--- a/app/src/main/res/drawable/ic_back_arrow.xml
+++ b/app/src/main/res/drawable/ic_back_arrow.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="15dp"
+    android:viewportWidth="9"
+    android:viewportHeight="15">
+  <path
+      android:pathData="M8.1758,1.8534C8.5921,1.4439 8.6081,0.7634 8.2115,0.3335C7.8149,-0.0964 7.1559,-0.1129 6.7396,0.2967C6.7396,0.2967 0.3157,6.7147 0.2981,6.7334C-0.1124,7.1769 -0.097,7.8801 0.3324,8.304L6.7396,14.7021C7.1552,15.1123 7.8142,15.097 8.2115,14.6678C8.6088,14.2386 8.5939,13.5581 8.1783,13.1478L2.9644,7.8513C2.7729,7.6568 2.7729,7.3445 2.9644,7.1499L8.1758,1.8534Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/layout/activity_polls.xml
+++ b/app/src/main/res/layout/activity_polls.xml
@@ -25,7 +25,7 @@
             android:background="@color/black"
             android:contentDescription="@string/go_back_content_description"
             android:onClick="goBack"
-            android:src="@drawable/arrow_back" />
+            android:src="@drawable/ic_back_arrow" />
 
         <TextView
             android:id="@+id/groupNameTextView"

--- a/app/src/main/res/layout/activity_polls_date.xml
+++ b/app/src/main/res/layout/activity_polls_date.xml
@@ -37,7 +37,7 @@
                         android:layout_marginStart="15dp"
                         android:background="@color/black"
                         android:contentDescription="@string/go_back_content_description"
-                        android:src="@drawable/arrow_back" />
+                        android:src="@drawable/ic_back_arrow" />
 
                     <TextView
                         android:id="@+id/groupNameTextView"

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -16,7 +16,6 @@
         android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/addGroupBar">
-
         <LinearLayout
             android:id="@+id/noGroupsView"
             android:layout_width="wrap_content"
@@ -53,15 +52,19 @@
                 android:text="@string/no_groups_joined_subtext" />
         </LinearLayout>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/group_list_recyclerView"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefresh"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            tools:context="com.google.samples.apps.sunflower.GardenActivity"
-            tools:listitem="@layout/group_list_item">
+            android:layout_height="match_parent">
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/group_list_recyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:context="com.google.samples.apps.sunflower.GardenActivity"
+                tools:listitem="@layout/group_list_item">
 
-        </androidx.recyclerview.widget.RecyclerView>
-
+            </androidx.recyclerview.widget.RecyclerView>
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </FrameLayout>
 
     <View

--- a/app/src/main/res/layout/polls_date_recyclerview_item_row.xml
+++ b/app/src/main/res/layout/polls_date_recyclerview_item_row.xml
@@ -49,7 +49,7 @@
         android:id="@+id/arrowIndicator"
         android:layout_width="11dp"
         android:layout_height="11dp"
-        android:src="@drawable/arrow_back_small"
+        android:src="@drawable/ic_back_arrow"
         android:layout_alignParentEnd="true"
         android:layout_marginEnd="16dp"
         android:layout_centerVertical="true"


### PR DESCRIPTION
## Overview
Fixed inconsistent poll counts caused by improper handling of poll deletion and some bugs mentioned by users during testing.

## Changes Made
- Fixed inconsistent poll counts by calling a socket method to alert delegates of poll deletion (#84)
- Fixed bug where poll numbering was off when a new poll started and users were automatically scrolled to the last card
- Fixed inaccurate poll result percentages
- Allow professors to see student responses that were made when they're in `PollsDateActivity`
- Bumped version code and some dependencies, and toggled a setting for `WebView` as recommended by Google
- Allow users to swipe down on tabs in the `viewPager` to refresh poll groups (#60)
- Make input auto-capitalized when users are entering a group code
- Allow users to dismiss group options popup by clicking on the dimmed view or by clicking on their phone's back button
- Replaced back arrows in `PollsActivity` and `PollsDateActivity` screens with carets, per designs

## Test Coverage
Play testing on Pixel 3 @ API 29.

## Screenshots
<details>
  <p>
    Carets in place of back arrows<br/>
    <img width="300" height="600" src="https://user-images.githubusercontent.com/19438967/96814257-b97a3100-13ea-11eb-9826-8fb0abeefc77.png">
    <img width="300" height="600" src="https://user-images.githubusercontent.com/19438967/96814285-bbdc8b00-13ea-11eb-8eaa-ad3856bb243c.png">
  </p>
</details>
