### PR TITLE
Handle exceptions and add connectivity banners

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,6 @@ android {
         versionName "1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "web_client_id", keyProperties['web_client_id'])
-        buildConfigField("String", "BACKEND_URI", "\"pollo-dev.cornellappdev.com\"")
     }
     buildTypes {
         debug {
@@ -25,12 +24,16 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField("boolean", "DUMMY_LOGIN_ENABLED", "true")
+            buildConfigField("String", "DUMMY_USER_ID1", "\"616647266964\"")
+            buildConfigField("String", "DUMMY_USER_ID2", "\"616647266965\"")
+            buildConfigField("String", "BACKEND_URI", "\"pollo-dev.cornellappdev.com\"")
         }
         release {
             manifestPlaceholders = [crashlyticsCollectionEnabled: "true"]
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField("boolean", "DUMMY_LOGIN_ENABLED", "false")
+            buildConfigField("String", "BACKEND_URI", "\"pollo-backend.cornellappdev.com\"")
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "com.cornellappdev.android.pollo"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 8
+        versionCode 9
         versionName "1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "web_client_id", keyProperties['web_client_id'])

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.cornellappdev.android.pollo">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
@@ -10,9 +10,10 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
 
 object ConnectivityBanner {
-    private var currContext: Context? = null;
+    private var currContext: Context? = null
     private var currView: View? = null
     private var isConnected = true
+    private var currSnackbar: Snackbar? = null
 
     // Registers a new NetworkCallback if one does not currently exist or updates existing network callback
     fun setUpConnectivityBanners(context: Context, view: View) {
@@ -43,13 +44,15 @@ object ConnectivityBanner {
             }
         }
     }
-    
+
     // Displays appropriate connectivity banner based on current connectivity status
     private fun displaySnackbar() {
+        currSnackbar?.dismiss()
         val color = ContextCompat.getColor(currContext!!, if (isConnected) R.color.polloGreen else R.color.red)
         val text = if (isConnected) "Connected" else "Not Connected"
         val duration = if (isConnected) Snackbar.LENGTH_SHORT else Snackbar.LENGTH_INDEFINITE
         val snackbar = Snackbar.make(currView!!, text, duration).setBackgroundTint(color)
         snackbar.show()
+        currSnackbar = snackbar
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
@@ -1,7 +1,6 @@
 package com.cornellappdev.android.pollo
 
 import android.content.Context
-import android.graphics.Color
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkRequest
@@ -9,47 +8,45 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
 
-object ConnectivityBanner {
-    private var currView: View? = null
-    private var isConnected = true
-    private var currSnackbar: Snackbar? = null
+class ConnectivityBanner(val context: Context) {
+    companion object {
+        private var callbackRegistered = false
+        private var isConnected = true
+    }
 
     // Registers a new NetworkCallback if one does not currently exist or updates existing network callback
-    fun setUpConnectivityBanners(context: Context, view: View) {
-        if (currView == null) {
-            currView = view
-            val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            val builder = NetworkRequest.Builder()
-            val callback = object : ConnectivityManager.NetworkCallback() {
-                override fun onAvailable(network: Network) {
-                    super.onAvailable(network)
+    fun setUpConnectivityBanners(view: View) {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val builder = NetworkRequest.Builder()
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                super.onAvailable(network)
+                if (callbackRegistered && !isConnected) {
                     isConnected = true
-                    displaySnackbar(context)
+                    displaySnackbar(view)
                 }
+            }
 
-                override fun onLost(network: Network) {
-                    super.onLost(network)
-                    isConnected = false
-                    displaySnackbar(context)
-                }
+            override fun onLost(network: Network) {
+                super.onLost(network)
+                isConnected = false
+                displaySnackbar(view)
             }
-            cm.registerNetworkCallback(builder.build(), callback)
-        } else {
-            currView = view
-            if (!isConnected) {
-                displaySnackbar(context)
-            }
+        }
+        cm.registerNetworkCallback(builder.build(), callback)
+
+        if (!callbackRegistered || !isConnected) {
+            displaySnackbar(view)
+            callbackRegistered = true
         }
     }
 
     // Displays appropriate connectivity banner based on current connectivity status
-    private fun displaySnackbar(context: Context) {
-        currSnackbar?.dismiss()
+    private fun displaySnackbar(view: View) {
         val color = ContextCompat.getColor(context, if (isConnected) R.color.polloGreen else R.color.red)
         val text = if (isConnected) "Connected" else "Not Connected"
         val duration = if (isConnected) Snackbar.LENGTH_SHORT else Snackbar.LENGTH_INDEFINITE
-        val snackbar = Snackbar.make(currView!!, text, duration).setBackgroundTint(color)
+        val snackbar = Snackbar.make(view, text, duration).setBackgroundTint(color)
         snackbar.show()
-        currSnackbar = snackbar
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
@@ -10,45 +10,42 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
 
 object ConnectivityBanner {
-    private var currContext: Context? = null
     private var currView: View? = null
     private var isConnected = true
     private var currSnackbar: Snackbar? = null
 
     // Registers a new NetworkCallback if one does not currently exist or updates existing network callback
     fun setUpConnectivityBanners(context: Context, view: View) {
-        if (currContext == null) {
-            currContext = context
+        if (currView == null) {
             currView = view
-            val cm = currContext!!.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
             val builder = NetworkRequest.Builder()
             val callback = object : ConnectivityManager.NetworkCallback() {
                 override fun onAvailable(network: Network) {
                     super.onAvailable(network)
                     isConnected = true
-                    displaySnackbar()
+                    displaySnackbar(context)
                 }
 
                 override fun onLost(network: Network) {
                     super.onLost(network)
                     isConnected = false
-                    displaySnackbar()
+                    displaySnackbar(context)
                 }
             }
             cm.registerNetworkCallback(builder.build(), callback)
         } else {
-            currContext = context
             currView = view
             if (!isConnected) {
-                displaySnackbar()
+                displaySnackbar(context)
             }
         }
     }
 
     // Displays appropriate connectivity banner based on current connectivity status
-    private fun displaySnackbar() {
+    private fun displaySnackbar(context: Context) {
         currSnackbar?.dismiss()
-        val color = ContextCompat.getColor(currContext!!, if (isConnected) R.color.polloGreen else R.color.red)
+        val color = ContextCompat.getColor(context, if (isConnected) R.color.polloGreen else R.color.red)
         val text = if (isConnected) "Connected" else "Not Connected"
         val duration = if (isConnected) Snackbar.LENGTH_SHORT else Snackbar.LENGTH_INDEFINITE
         val snackbar = Snackbar.make(currView!!, text, duration).setBackgroundTint(color)

--- a/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
@@ -1,6 +1,7 @@
 package com.cornellappdev.android.pollo
 
 import android.content.Context
+import android.graphics.Color
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkRequest
@@ -11,6 +12,7 @@ import com.google.android.material.snackbar.Snackbar
 object ConnectivityBanner {
     private var currContext: Context? = null;
     private var currView: View? = null
+    private var isConnected = true
 
     // Registers a new NetworkCallback if one does not currently exist or updates existing network callback
     fun setUpConnectivityBanners(context: Context, view: View) {
@@ -22,22 +24,32 @@ object ConnectivityBanner {
             val callback = object : ConnectivityManager.NetworkCallback() {
                 override fun onAvailable(network: Network) {
                     super.onAvailable(network)
-                    val polloGreen = ContextCompat.getColor(currContext!!, R.color.polloGreen)
-                    val snackbar = Snackbar.make(currView!!, "Connected", Snackbar.LENGTH_SHORT).setBackgroundTint(polloGreen)
-                    snackbar.show()
+                    isConnected = true
+                    displaySnackbar()
                 }
 
                 override fun onLost(network: Network) {
                     super.onLost(network)
-                    val errorRed = ContextCompat.getColor(currContext!!, R.color.red)
-                    val snackbar = Snackbar.make(currView!!, "Not Connected", Snackbar.LENGTH_LONG).setBackgroundTint(errorRed)
-                    snackbar.show()
+                    isConnected = false
+                    displaySnackbar()
                 }
             }
             cm.registerNetworkCallback(builder.build(), callback)
         } else {
             currContext = context
             currView = view
+            if (!isConnected) {
+                displaySnackbar()
+            }
         }
+    }
+    
+    // Displays appropriate connectivity banner based on current connectivity status
+    private fun displaySnackbar() {
+        val color = ContextCompat.getColor(currContext!!, if (isConnected) R.color.polloGreen else R.color.red)
+        val text = if (isConnected) "Connected" else "Not Connected"
+        val duration = if (isConnected) Snackbar.LENGTH_SHORT else Snackbar.LENGTH_INDEFINITE
+        val snackbar = Snackbar.make(currView!!, text, duration).setBackgroundTint(color)
+        snackbar.show()
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/ConnectivityBanner.kt
@@ -1,0 +1,43 @@
+package com.cornellappdev.android.pollo
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkRequest
+import android.view.View
+import androidx.core.content.ContextCompat
+import com.google.android.material.snackbar.Snackbar
+
+object ConnectivityBanner {
+    private var currContext: Context? = null;
+    private var currView: View? = null
+
+    // Registers a new NetworkCallback if one does not currently exist or updates existing network callback
+    fun setUpConnectivityBanners(context: Context, view: View) {
+        if (currContext == null) {
+            currContext = context
+            currView = view
+            val cm = currContext!!.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val builder = NetworkRequest.Builder()
+            val callback = object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    super.onAvailable(network)
+                    val polloGreen = ContextCompat.getColor(currContext!!, R.color.polloGreen)
+                    val snackbar = Snackbar.make(currView!!, "Connected", Snackbar.LENGTH_SHORT).setBackgroundTint(polloGreen)
+                    snackbar.show()
+                }
+
+                override fun onLost(network: Network) {
+                    super.onLost(network)
+                    val errorRed = ContextCompat.getColor(currContext!!, R.color.red)
+                    val snackbar = Snackbar.make(currView!!, "Not Connected", Snackbar.LENGTH_LONG).setBackgroundTint(errorRed)
+                    snackbar.show()
+                }
+            }
+            cm.registerNetworkCallback(builder.build(), callback)
+        } else {
+            currContext = context
+            currView = view
+        }
+    }
+}

--- a/app/src/main/java/com/cornellappdev/android/pollo/CreatePollFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/CreatePollFragment.kt
@@ -58,6 +58,7 @@ class CreatePollFragment : Fragment(), SavedPollAdapter.SavedPollDelegate, Saved
             savedInstanceState: Bundle?
     ): View? {
         val rootView = inflater.inflate(R.layout.fragment_create_poll, container, false)
+        rootView.isClickable = true
 
         options = arrayListOf()
         createPollAdapter = CreatePollAdapter(requireContext(), options, -1, this)
@@ -399,6 +400,9 @@ class CreatePollFragment : Fragment(), SavedPollAdapter.SavedPollDelegate, Saved
         view.setBackgroundColor(Color.TRANSPARENT)
         view.create_poll_options_text.setHintTextColor(Color.TRANSPARENT)
         view.create_poll_options_item.buttonTintList = ColorStateList.valueOf(Color.WHITE)
+        view.create_poll_options_text.isClickable = false
+        view.create_poll_options_text.isEnabled = false
+        view.deleteOption.visibility = View.GONE
     }
 
     /**
@@ -416,7 +420,7 @@ class CreatePollFragment : Fragment(), SavedPollAdapter.SavedPollDelegate, Saved
         }
     }
 
-    fun dismissPopup() {
+    private fun dismissPopup() {
         if (!isPopupActive) return
         isPopupActive = false
         setDim(false)

--- a/app/src/main/java/com/cornellappdev/android/pollo/ExceptionHelper.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/ExceptionHelper.kt
@@ -1,4 +1,4 @@
-package com.cornellappdev.android.pollo.networking
+package com.cornellappdev.android.pollo
 
 import android.app.Activity
 import android.app.AlertDialog
@@ -6,8 +6,8 @@ import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.CoroutineExceptionHandler
 
-object ExceptionHandlerFactory {
-    fun getCoroutineExceptionHandler(context: Context, errorMessage: String): CoroutineExceptionHandler {
+object ExceptionHelper {
+    fun getExceptionHandler(context: Context, errorMessage: String): CoroutineExceptionHandler {
         return CoroutineExceptionHandler { _, exception ->
             Log.d("CoroutineException", "Exception $exception thrown. Error message: $errorMessage")
             (context as Activity).runOnUiThread {

--- a/app/src/main/java/com/cornellappdev/android/pollo/ExceptionHelper.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/ExceptionHelper.kt
@@ -5,18 +5,43 @@ import android.app.AlertDialog
 import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.CoroutineExceptionHandler
+import java.util.concurrent.atomic.AtomicBoolean
 
 object ExceptionHelper {
-    fun getExceptionHandler(context: Context, errorMessage: String): CoroutineExceptionHandler {
-        return CoroutineExceptionHandler { _, exception ->
-            Log.d("CoroutineException", "Exception $exception thrown. Error message: $errorMessage")
-            (context as Activity).runOnUiThread {
-                AlertDialog.Builder(context)
-                        .setTitle(errorMessage)
-                        .setMessage("Please try again later.")
-                        .setNeutralButton(android.R.string.ok, null)
-                        .show()
-            }
+    private var alertShown = AtomicBoolean(false)
+
+    fun getThreadExceptionHandler(context: Context, errorTitle: String, callback: ResettableView?): Thread.UncaughtExceptionHandler {
+        return Thread.UncaughtExceptionHandler { _, exception ->
+            handleException(context, errorTitle, callback, exception)
         }
+    }
+
+    fun getCoroutineExceptionHandler(context: Context, errorTitle: String, callback: ResettableView?): CoroutineExceptionHandler {
+        return CoroutineExceptionHandler { _, exception ->
+            handleException(context, errorTitle, callback, exception)
+        }
+    }
+
+    private fun handleException(context: Context, errorMessage: String, callback: ResettableView?, exception: Throwable) {
+        Log.d("CoroutineException", "Exception $exception thrown. Error message: $errorMessage")
+        if (!alertShown.get()) {
+            alertShown.set(true)
+            displayAlert(context, errorMessage) { alertShown.set(false) }
+        }
+        callback?.reset()
+    }
+
+    fun displayAlert(context: Context, errorTitle: String, alertClosedAction: () -> Unit) {
+        (context as Activity).runOnUiThread {
+            AlertDialog.Builder(context)
+                    .setTitle(errorTitle)
+                    .setMessage("Please try again later.")
+                    .setNeutralButton(android.R.string.ok) { _, _ -> alertClosedAction() }
+                    .show()
+        }
+    }
+
+    interface ResettableView {
+        fun reset()
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/pollo/ExceptionHelper.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/ExceptionHelper.kt
@@ -10,25 +10,25 @@ import java.util.concurrent.atomic.AtomicBoolean
 object ExceptionHelper {
     private var alertShown = AtomicBoolean(false)
 
-    fun getThreadExceptionHandler(context: Context, errorTitle: String, callback: ResettableView?): Thread.UncaughtExceptionHandler {
+    fun getThreadExceptionHandler(context: Context, errorTitle: String, callback: () -> Unit): Thread.UncaughtExceptionHandler {
         return Thread.UncaughtExceptionHandler { _, exception ->
             handleException(context, errorTitle, callback, exception)
         }
     }
 
-    fun getCoroutineExceptionHandler(context: Context, errorTitle: String, callback: ResettableView?): CoroutineExceptionHandler {
+    fun getCoroutineExceptionHandler(context: Context, errorTitle: String, callback: () -> Unit): CoroutineExceptionHandler {
         return CoroutineExceptionHandler { _, exception ->
             handleException(context, errorTitle, callback, exception)
         }
     }
 
-    private fun handleException(context: Context, errorMessage: String, callback: ResettableView?, exception: Throwable) {
+    private fun handleException(context: Context, errorMessage: String, callback: () -> Unit, exception: Throwable) {
         Log.d("CoroutineException", "Exception $exception thrown. Error message: $errorMessage")
         if (!alertShown.get()) {
             alertShown.set(true)
             displayAlert(context, errorMessage) { alertShown.set(false) }
         }
-        callback?.reset()
+        callback()
     }
 
     fun displayAlert(context: Context, errorTitle: String, alertClosedAction: () -> Unit) {
@@ -39,9 +39,5 @@ object ExceptionHelper {
                     .setNeutralButton(android.R.string.ok) { _, _ -> alertClosedAction() }
                     .show()
         }
-    }
-
-    interface ResettableView {
-        fun reset()
     }
 }

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.withContext
  * create an instance of this fragment.
  */
 @SuppressLint("ValidFragment")
-class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListener, ExceptionHelper.ResettableView {
+class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListener {
 
     private var sectionNumber: Int = 0
     private var currentAdapter: GroupRecyclerAdapter? = null
@@ -210,12 +210,12 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
     }
 
     private fun setExceptionHandler() {
-        Thread.setDefaultUncaughtExceptionHandler(ExceptionHelper.getThreadExceptionHandler(requireContext(), "Group Operation Failed", this))
+        Thread.setDefaultUncaughtExceptionHandler(ExceptionHelper.getThreadExceptionHandler(requireContext(), "Group Operation Failed") { reset() })
     }
 
     fun refreshGroups() {
         if (role == null) return
-        val handler = ExceptionHelper.getCoroutineExceptionHandler(requireContext(), "Could Not Fetch Groups", this)
+        val handler = ExceptionHelper.getCoroutineExceptionHandler(requireContext(), "Could Not Fetch Groups") { reset() }
         CoroutineScope(Dispatchers.IO).launch(handler) {
             val getGroupsEndpoint = Endpoint.getAllGroups(role!!.name.toLowerCase())
             val typeTokenGroups = object : TypeToken<ApiResponse<ArrayList<Group>>>() {}.type
@@ -224,7 +224,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
             withContext(Dispatchers.Main.immediate) {
                 if (getGroupsResponse?.success == false || getGroupsResponse?.data == null) {
                     withContext(Dispatchers.Main) {
-                        ExceptionHelper.displayAlert(requireContext(), "Could Not Fetch Groups"){}
+                        ExceptionHelper.displayAlert(requireContext(), "Could Not Fetch Groups") {}
                     }
                     return@withContext
                 }
@@ -516,7 +516,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
 
             if (groupResponse?.success == false || groupResponse?.data == null) {
                 withContext(Dispatchers.Main) {
-                    ExceptionHelper.displayAlert(requireContext(), "Group Rename Failed"){}
+                    ExceptionHelper.displayAlert(requireContext(), "Group Rename Failed") {}
                 }
                 return@launch
             }
@@ -566,7 +566,7 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
         fun startGroupActivity(role: User.Role, group: Group, polls: ArrayList<GetSortedPollsResponse>)
     }
 
-    override fun reset() {
+    private fun reset() {
         swipeRefresh?.isRefreshing = false
         dismissPopup()
     }

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupRecyclerView.kt
@@ -35,7 +35,7 @@ class GroupRecyclerAdapter(
     }
 
 
-    inner class ViewHolder internal constructor(view: View) : androidx.recyclerview.widget.RecyclerView.ViewHolder(view), View.OnClickListener, ExceptionHelper.ResettableView {
+    inner class ViewHolder internal constructor(view: View) : androidx.recyclerview.widget.RecyclerView.ViewHolder(view), View.OnClickListener {
 
         private var view = view
         private var group: Group? = null
@@ -57,7 +57,11 @@ class GroupRecyclerAdapter(
             view.groupDetailsButton.visibility = View.GONE
             view.groupLoadingIndicator.visibility = View.VISIBLE
 
-            val handler = ExceptionHelper.getCoroutineExceptionHandler(view.context, "Failed to Enter Group", this)
+            val handler = ExceptionHelper.getCoroutineExceptionHandler(view.context, "Failed to Enter Group") {
+                view.groupDetailsButton.visibility = View.VISIBLE
+                view.groupLoadingIndicator.visibility = View.GONE
+                isLoading = false
+            }
             CoroutineScope(Dispatchers.Main).launch(handler) {
                 val endpoint = Endpoint.joinGroupWithCode(group?.code ?: "")
                 val typeTokenGroupNode = object : TypeToken<ApiResponse<Group>>() {}.type
@@ -72,7 +76,7 @@ class GroupRecyclerAdapter(
                 val pollsDateActivity = Intent(context, PollsDateActivity::class.java)
                 pollsDateActivity.putExtra("SORTED_POLLS", sortedPolls!!.data)
                 pollsDateActivity.putExtra("GROUP_NODE", group)
-                pollsDateActivity.putExtra("USER_ROLE",role)
+                pollsDateActivity.putExtra("USER_ROLE", role)
                 context.startActivity(pollsDateActivity)
 
                 view.groupDetailsButton.visibility = View.VISIBLE
@@ -98,7 +102,7 @@ class GroupRecyclerAdapter(
                     if (timeSplit[i] > 0) break
 
                     // To handle issue where `group.updatedAt` is greater than the current time
-                    if (i == TIME_LABELS.size-1) timeResult = "1 " + TIME_LABELS[i]
+                    if (i == TIME_LABELS.size - 1) timeResult = "1 " + TIME_LABELS[i]
                 }
 
                 if (timeResult[0] == '1') {
@@ -107,12 +111,6 @@ class GroupRecyclerAdapter(
                 view.groupLiveTextView.text = "${group.code}  •  Last live $timeResult ago"
                 view.groupLiveTextView.setTextColor(ContextCompat.getColor(view.context, R.color.settings_detail))
             }
-        }
-
-        override fun reset() {
-            view.groupDetailsButton.visibility = View.VISIBLE
-            view.groupLoadingIndicator.visibility = View.GONE
-            isLoading = false
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/LoginActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/LoginActivity.kt
@@ -29,9 +29,6 @@ import kotlinx.coroutines.withContext
 
 class LoginActivity : AppCompatActivity() {
 
-    private val dummyUserId1 = "616647266964"
-    private val dummyUserId2 = "616647266965"
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
@@ -53,20 +50,21 @@ class LoginActivity : AppCompatActivity() {
             webview.visibility = View.VISIBLE
         }
 
+        // Dummy login, to be removed before pushing to production
         if (BuildConfig.DUMMY_LOGIN_ENABLED) {
             val buttons = arrayOf(dummy_login_button, dummy_login_button_2)
             for ((i, button) in buttons.withIndex()) {
                 button.visibility = View.VISIBLE
                 button.text = getString(R.string.dummy_login, i)
                 button.setOnClickListener {
-                    dummyLogin(it)
+                    val userId = if (i == 0) BuildConfig.DUMMY_USER_ID1 else BuildConfig.DUMMY_USER_ID2
+                    dummyLogin(userId)
                 }
             }
         }
     }
 
-    private fun dummyLogin(view: View) {
-        val userId = if (view == dummy_login_button) dummyUserId1 else dummyUserId2
+    private fun dummyLogin(userId: String) {
         CoroutineScope(Dispatchers.Main).launch {
             val dummyLoginEndpoint = Endpoint.dummyUserLogin(userId)
             val typeToken = object : TypeToken<ApiResponse<UserSession>>() {}.type

--- a/app/src/main/java/com/cornellappdev/android/pollo/LoginActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/LoginActivity.kt
@@ -29,6 +29,9 @@ import kotlinx.coroutines.withContext
 
 class LoginActivity : AppCompatActivity() {
 
+    private val dummyUserId1 = "616647266964"
+    private val dummyUserId2 = "616647266965"
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
@@ -48,6 +51,29 @@ class LoginActivity : AppCompatActivity() {
             val host = "https://" + BuildConfig.BACKEND_URI + "/api/v2/auth/saml/cornell/"
             webview.loadUrl(host)
             webview.visibility = View.VISIBLE
+        }
+
+        if (BuildConfig.DUMMY_LOGIN_ENABLED) {
+            val buttons = arrayOf(dummy_login_button, dummy_login_button_2)
+            for ((i, button) in buttons.withIndex()) {
+                button.visibility = View.VISIBLE
+                button.text = getString(R.string.dummy_login, i)
+                button.setOnClickListener {
+                    dummyLogin(it)
+                }
+            }
+        }
+    }
+
+    private fun dummyLogin(view: View) {
+        val userId = if (view == dummy_login_button) dummyUserId1 else dummyUserId2
+        CoroutineScope(Dispatchers.Main).launch {
+            val dummyLoginEndpoint = Endpoint.dummyUserLogin(userId)
+            val typeToken = object : TypeToken<ApiResponse<UserSession>>() {}.type
+            val userSession = withContext(Dispatchers.IO) {
+                Request.makeRequest<ApiResponse<UserSession>>(dummyLoginEndpoint.okHttpRequest(), typeToken)
+            }!!.data
+            sendSessionInfo(userSession)
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -46,35 +46,26 @@ class MainActivity : AppCompatActivity(), GroupFragment.GroupFragmentDelegate {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        // If there is no accessToken in preferences, attempt to sign in, otherwise launch the normal activity
-        if (preferencesHelper.accessToken!!.isNotEmpty()) {
-            val expiresAt = preferencesHelper.expiresAt
-            val dateAccessTokenExpires = Date(expiresAt * 1000)
-            val currentDate = Date()
-            val isAccessTokenExpired = currentDate >= dateAccessTokenExpires
+        // If there is no refresh token in preferences, attempt to sign in, otherwise launch the normal activity
+        if (preferencesHelper.refreshToken!!.isNotEmpty()) {
+            // Always attempt to refresh to reduce chances of access token expiring during user session
             CoroutineScope(Dispatchers.Main).launch {
-                if (isAccessTokenExpired) {
+                try {
                     val refreshTokenEndpoint = Endpoint.userRefreshSession(preferencesHelper.refreshToken as String)
                     val typeToken = object : TypeToken<ApiResponse<UserSession>>() {}.type
                     val userSession = withContext(Dispatchers.IO) {
                         Request.makeRequest<ApiResponse<UserSession>>(refreshTokenEndpoint.okHttpRequest(), typeToken)
                     }!!.data
                     User.currentSession = userSession
-
-                    if (userSession.sessionExpiration == null) {
-                        val signInIntent = Intent(this@MainActivity, LoginActivity::class.java)
-                        startActivityForResult(signInIntent, LOGIN_REQ_CODE)
-                        return@launch
-                    }
-
                     preferencesHelper.refreshToken = userSession.refreshToken
                     preferencesHelper.accessToken = userSession.accessToken
                     preferencesHelper.expiresAt = userSession.sessionExpiration.toLong()
-                } else {
-                    User.currentSession = UserSession(preferencesHelper.accessToken, preferencesHelper.refreshToken, expiresAt.toString(), true)
+                    finishAuthFlow()
+                } catch (e: Exception) {
+                    val signInIntent = Intent(this@MainActivity, LoginActivity::class.java)
+                    startActivityForResult(signInIntent, LOGIN_REQ_CODE)
+                    return@launch
                 }
-
-                finishAuthFlow()
             }
             return
         }

--- a/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : AppCompatActivity(), GroupFragment.GroupFragmentDelegate {
         // If there is no refresh token in preferences, attempt to sign in, otherwise launch the normal activity
         if (preferencesHelper.refreshToken!!.isNotEmpty()) {
             // Always attempt to refresh to reduce chances of access token expiring during user session
-            CoroutineScope(Dispatchers.Main).launch {
+            CoroutineScope(Dispatchers.IO).launch {
                 try {
                     val refreshTokenEndpoint = Endpoint.userRefreshSession(preferencesHelper.refreshToken as String)
                     val typeToken = object : TypeToken<ApiResponse<UserSession>>() {}.type
@@ -60,7 +60,9 @@ class MainActivity : AppCompatActivity(), GroupFragment.GroupFragmentDelegate {
                     preferencesHelper.refreshToken = userSession.refreshToken
                     preferencesHelper.accessToken = userSession.accessToken
                     preferencesHelper.expiresAt = userSession.sessionExpiration.toLong()
-                    finishAuthFlow()
+                    withContext(Dispatchers.Main) {
+                        finishAuthFlow()
+                    }
                 } catch (e: Exception) {
                     val signInIntent = Intent(this@MainActivity, LoginActivity::class.java)
                     startActivityForResult(signInIntent, LOGIN_REQ_CODE)

--- a/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.PagerSnapHelper
 import androidx.recyclerview.widget.RecyclerView
+import com.cornellappdev.android.pollo.ConnectivityBanner
 import com.cornellappdev.android.pollo.R
 import com.cornellappdev.android.pollo.models.Poll
 import com.cornellappdev.android.pollo.models.PollState
@@ -73,6 +74,11 @@ class PollsActivity : AppCompatActivity(), SocketDelegate, PollsRecyclerAdapter.
             }
         })
 
+    }
+
+    override fun onResume() {
+        super.onResume()
+        ConnectivityBanner.setUpConnectivityBanners(this, findViewById(android.R.id.content))
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsActivity.kt
@@ -78,7 +78,7 @@ class PollsActivity : AppCompatActivity(), SocketDelegate, PollsRecyclerAdapter.
 
     override fun onResume() {
         super.onResume()
-        ConnectivityBanner.setUpConnectivityBanners(this, findViewById(android.R.id.content))
+        ConnectivityBanner(this).setUpConnectivityBanners(findViewById(android.R.id.content))
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
@@ -316,7 +316,7 @@ class PollsDateActivity : AppCompatActivity(), SocketDelegate, View.OnClickListe
         toggleEmptyState()
     }
 
-    fun openNewPollFragment(view: View) {
+    private fun openNewPollFragment(view: View) {
         supportFragmentManager.beginTransaction()
                 .setCustomAnimations(R.anim.slide_up, R.anim.slide_down, R.anim.slide_up, R.anim.slide_down)
                 .add(R.id.polls_date_layout, CreatePollFragment()).addToBackStack(null).commit()

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
@@ -73,7 +73,7 @@ class PollsDateActivity : AppCompatActivity(), SocketDelegate, View.OnClickListe
 
     override fun onResume() {
         super.onResume()
-        ConnectivityBanner.setUpConnectivityBanners(this, findViewById(android.R.id.content))
+        ConnectivityBanner(this).setUpConnectivityBanners(findViewById(android.R.id.content))
         refreshPolls(false)
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
@@ -73,7 +73,7 @@ class PollsDateActivity : AppCompatActivity(), SocketDelegate, View.OnClickListe
 
     override fun onResume() {
         super.onResume()
-        refreshPolls()
+        refreshPolls(false)
     }
 
     fun goBack(view: View) {
@@ -90,12 +90,17 @@ class PollsDateActivity : AppCompatActivity(), SocketDelegate, View.OnClickListe
     fun startNewPoll(newPoll: Poll) {
         Socket.serverStart(newPoll)
         supportFragmentManager.popBackStack()
-        refreshPolls()
+        refreshPolls(true)
         onPollStart(newPoll)
     }
 
-    private fun refreshPolls() {
-        CoroutineScope(Dispatchers.Main).launch {
+    private fun refreshPolls(newPollCreated: Boolean) {
+        val handler = ExceptionHelper.getCoroutineExceptionHandler(this, "Failed to Update Polls") {
+            if (newPollCreated) {
+                onPollDeleteLive()
+            }
+        }
+        CoroutineScope(Dispatchers.Main).launch(handler) {
             val endpoint = Endpoint.joinGroupWithCode(group.code)
             val typeTokenGroupNode = object : TypeToken<ApiResponse<Group>>() {}.type
             val typeTokenSortedPolls = object : TypeToken<ApiResponse<ArrayList<GetSortedPollsResponse>>>() {}.type
@@ -315,5 +320,4 @@ class PollsDateActivity : AppCompatActivity(), SocketDelegate, View.OnClickListe
                 .setCustomAnimations(R.anim.slide_up, R.anim.slide_down, R.anim.slide_up, R.anim.slide_down)
                 .add(R.id.polls_date_layout, CreatePollFragment()).addToBackStack(null).commit()
     }
-
 }

--- a/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/PollsDateActivity.kt
@@ -73,6 +73,7 @@ class PollsDateActivity : AppCompatActivity(), SocketDelegate, View.OnClickListe
 
     override fun onResume() {
         super.onResume()
+        ConnectivityBanner.setUpConnectivityBanners(this, findViewById(android.R.id.content))
         refreshPolls(false)
     }
 

--- a/app/src/main/java/com/cornellappdev/android/pollo/SettingsActivity.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/SettingsActivity.kt
@@ -49,10 +49,6 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     fun logoutButtonClicked(view: View) {
-        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-                .requestProfile()
-                .build()
-        GoogleSignIn.getClient(this, gso).signOut()
         preferencesHelper.accessToken = ""
         preferencesHelper.refreshToken = ""
         preferencesHelper.expiresAt = 0L

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/ExceptionHandlerFactory.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/ExceptionHandlerFactory.kt
@@ -1,0 +1,22 @@
+package com.cornellappdev.android.pollo.networking
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+object ExceptionHandlerFactory {
+    fun getCoroutineExceptionHandler(context: Context, errorMessage: String): CoroutineExceptionHandler {
+        return CoroutineExceptionHandler { _, exception ->
+            Log.d("CoroutineException", "Exception $exception thrown. Error message: $errorMessage")
+            (context as Activity).runOnUiThread {
+                AlertDialog.Builder(context)
+                        .setTitle(errorMessage)
+                        .setMessage("Please try again later.")
+                        .setNeutralButton(android.R.string.ok, null)
+                        .show()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/Socket.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/Socket.kt
@@ -24,8 +24,6 @@ interface SocketDelegate {
 
 object Socket {
 
-    data class PollFilter(val success: Boolean, val text: String?, val filter: ArrayList<String>?)
-
     private var delegates = ArrayList<SocketDelegate>()
     private lateinit var manager: Manager
     private lateinit var socket: Socket

--- a/app/src/main/java/com/cornellappdev/android/pollo/networking/UserEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/networking/UserEndpoints.kt
@@ -10,6 +10,6 @@ fun Endpoint.Companion.userRefreshSession(refreshToken: String): Endpoint {
     return Endpoint(path = "/auth/refresh", headers = mapOf("Authorization" to "Bearer $refreshToken"), method = EndpointMethod.POST)
 }
 
-fun Endpoint.Companion.dummyUserLogin(): Endpoint {
-    return Endpoint(path = "/auth/fake/android/616647266964", method = EndpointMethod.POST)
+fun Endpoint.Companion.dummyUserLogin(dummyUserId: String): Endpoint {
+    return Endpoint(path = "/auth/fake/android/$dummyUserId", method = EndpointMethod.POST)
 }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -64,7 +64,17 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:backgroundTint="@color/actualWhite"
-            android:text="@string/dummy_login"
+            android:textAllCaps="false"
+            android:textColor="@color/loginGray"
+            android:visibility="gone" />
+
+        <Button
+            android:id="@+id/dummy_login_button_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:backgroundTint="@color/actualWhite"
+            android:textAllCaps="false"
             android:textColor="@color/loginGray"
             android:visibility="gone" />
 

--- a/app/src/main/res/layout/create_poll_onboarding.xml
+++ b/app/src/main/res/layout/create_poll_onboarding.xml
@@ -142,9 +142,9 @@
         <Button
             android:id="@+id/add_poll_option_outline"
             android:layout_width="0dp"
-            android:layout_height="54dp"
+            android:layout_height="56dp"
             android:layout_marginStart="25dp"
-            android:layout_marginTop="6dp"
+            android:layout_marginTop="10dp"
             android:layout_marginEnd="25dp"
             android:background="@drawable/rounded_container_outline"
             android:drawableStart="@drawable/plus_sign_white"

--- a/app/src/main/res/layout/polls_date_recyclerview_item_row.xml
+++ b/app/src/main/res/layout/polls_date_recyclerview_item_row.xml
@@ -10,8 +10,8 @@
 
     <TextView
         android:id="@+id/liveIndicator"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="10dp"
+        android:layout_height="10dp"
         android:layout_alignParentTop="true"
         android:layout_alignParentBottom="true"
         android:layout_marginStart="10dp"

--- a/app/src/main/res/layout/polls_date_recyclerview_item_row.xml
+++ b/app/src/main/res/layout/polls_date_recyclerview_item_row.xml
@@ -10,13 +10,19 @@
 
     <TextView
         android:id="@+id/liveIndicator"
-        android:layout_width="6dp"
-        android:layout_height="6dp"
-        android:text="@string/live_indicator"
-        android:layout_centerVertical="true"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentBottom="true"
         android:layout_marginStart="10dp"
+        android:layout_marginTop="0dp"
+        android:layout_marginBottom="0dp"
+        android:gravity="center"
+        android:paddingBottom="4dp"
+        android:text="@string/live_indicator"
         android:textColor="@color/liveNow"
-        android:visibility="invisible"/>
+        android:textSize="36sp"
+        android:visibility="visible" />
 
     <TextView
         android:id="@+id/pollDateTextView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
 
     <string name="app_name">Pollo</string>
     <string name="sign_in">Sign in with Cornell SSO</string>
-    <string name="dummy_login">Dummy Login</string>
+    <string name="dummy_login">Dummy Login User %1$d</string>
 
     <string name="close_detail_menu_content_description">Close Detail Menu</string>
 


### PR DESCRIPTION
## Overview
Implemented session refresh on app start, handled exceptions to reduce app crashes, and added connectivity banners.

## Changes Made
Refresh Session on App Start
- Always attempt to refresh user session if they've already logged in, so that there's a reduced chance of their session expiring in the middle of a poll
- Redirect user to log in if the refresh fails

Handle Exceptions
- Created an `ExceptionHelper` class that creates exception handlers
- Added exception handlers in `CreatePollFragment`, `GroupFragment`, `GroupRecyclerView`, and `PollsDateActivity`, as those are the places where Coroutines are used. Prior to this PR, attempts to make network calls when not connected to WiFi would cause app crashes
- Factored out a few different alerts into calls to a single method in `ExceptionHelper`

Connectivity Banners
- Added permission `android.permission.ACCESS_NETWORK_STATE` to the manifest
- Created a `ConnectivityBanner` class that registers a `NetworkCallback` so appropriate connectivity banners appear when the network status changes
- Connectivity banners are currently only displayed in `PollsDateActivity` and `PollsActivity` for consistency with iOS
- When network connection is lost, the red "Not Connected" banner will persist until a connection is regained as long as the user does not navigate to an activity other than `PollsDateActivity` and `PollsActivity`

Miscellaneous
- Bumped `versionCode`
- Removed some unused code
- Made a small change to "Add Option" outline in an onboarding screen
- Stopped users from repeatedly bringing up new CreatePollFragments by repeatedly clicking on the top right corner of the fragment
- Disabled onboarding EditTexts so they aren't editable
- Added live indicator in `PollsDateActivity`
- Added 2 dummy login buttons in `LoginActivity` that allows devs to login as 2 different dummy users on the debug build

## Test Coverage
Play testing on Pixel 3 @ API 29 and Pixel 2 @ API 27

## Related PRs or Issues
#81 #46 #82 



## Screenshots

<details>
  <p>
    Connectivity banners
    <br/>
    <img width="300" height="600" src="https://user-images.githubusercontent.com/19438967/98032247-b9faca80-1de1-11eb-87ec-a8802bf5533f.png">
    <img width="300" height="600" src="https://user-images.githubusercontent.com/19438967/98032281-c67f2300-1de1-11eb-895d-ae8f5baa56de.png">
  </p>
  <p>
    Live Indicator
    <br/>
    <img width="300" height="600" src="https://user-images.githubusercontent.com/19438967/98452496-d7030680-211d-11eb-9c42-c03cfccdc454.png">
  </p>
</details>
