### PR TITLE
flexible poll height, join group filter

### DIFF
--- a/app/src/main/java/com/cornellappdev/android/pollo/CreatePollFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/CreatePollFragment.kt
@@ -77,7 +77,8 @@ class CreatePollFragment : Fragment(), SavedPollAdapter.SavedPollDelegate, Saved
 
         addOption.setOnClickListener {
             addOptionToList()
-            if (options.size > 2) createPollAdapter?.deletable = true
+            createPollAdapter?.deletable = options.size >= 3
+            add_poll_option_button.visibility = if (options.size > 25) View.GONE else View.VISIBLE
             resetPollHeight()
 
         }
@@ -310,8 +311,11 @@ class CreatePollFragment : Fragment(), SavedPollAdapter.SavedPollDelegate, Saved
         createPollAdapter!!.resetCorrectness()
         options.clear()
         options.addAll(savedPoll.options)
+        createPollAdapter?.deletable = options.size >= 3
         createPollAdapter?.notifyDataSetChanged()
+        add_poll_option_button.visibility = if (options.size > 25) View.GONE else View.VISIBLE
         resetPollHeight()
+
 
     }
 
@@ -487,8 +491,7 @@ class CreatePollFragment : Fragment(), SavedPollAdapter.SavedPollDelegate, Saved
         val correct = createPollAdapter?.getCorrectness()
         if (correct == position) createPollAdapter?.resetCorrectness()
         if (correct!! > position) createPollAdapter?.decreaseCorrectness()
-        if (options.size < 3) createPollAdapter?.deletable = false
-
+        createPollAdapter?.deletable = options.size >= 3
         createPollAdapter?.notifyDataSetChanged()
         resetPollHeight()
     }

--- a/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/GroupFragment.kt
@@ -33,7 +33,6 @@ import com.google.gson.reflect.TypeToken
 import kotlinx.android.synthetic.main.fragment_main.*
 import kotlinx.android.synthetic.main.manage_group_view.*
 import kotlinx.android.synthetic.main.manage_group_view.view.*
-import kotlinx.android.synthetic.main.manage_group_view.view.renameGroupDetail
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -62,8 +61,10 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
     private var groups = ArrayList<Group>()
     private var groupSelected: Group? = null
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?): View {
+    override fun onCreateView(
+            inflater: LayoutInflater, container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View {
         val rootView = inflater.inflate(R.layout.fragment_main, container, false)
         role = arguments?.getSerializable(GROUP_ROLE) as User.Role
 
@@ -161,7 +162,8 @@ class GroupFragment : Fragment(), GroupRecyclerAdapter.OnMoreButtonPressedListen
                 addGroupEditText.setHint(R.string.join_group_hint)
                 addGroupEditText.setTextColor(Color.WHITE)
                 addGroupEditText.isAllCaps = true
-                addGroupEditText.inputType = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS
+
+                addGroupEditText.inputType = InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS or InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
                 addGroupEditText.filters = addGroupEditText.filters +
                         InputFilter.AllCaps() +
                         InputFilter.LengthFilter(6) +

--- a/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsRecyclerAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/android/pollo/Polls/PollsRecyclerAdapter.kt
@@ -6,18 +6,17 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
-import com.cornellappdev.android.pollo.R
-import com.cornellappdev.android.pollo.inflate
-import com.cornellappdev.android.pollo.networking.Socket
-import kotlinx.android.synthetic.main.poll_recyclerview_item_row.view.*
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.cornellappdev.android.pollo.R
+import com.cornellappdev.android.pollo.inflate
 import com.cornellappdev.android.pollo.models.Poll
 import com.cornellappdev.android.pollo.models.PollState
 import com.cornellappdev.android.pollo.models.User
+import com.cornellappdev.android.pollo.networking.Socket
+import kotlinx.android.synthetic.main.poll_recyclerview_item_row.view.*
 import java.util.*
-import kotlin.collections.ArrayList
 
 interface AnswerChoiceDelegate {
     fun sendAnswer(position: Int)
@@ -42,8 +41,9 @@ class PollsRecyclerAdapter(
     override fun onBindViewHolder(holder: PollHolder, position: Int) {
 
         val poll = polls[position]
+        val displayMetrics = Resources.getSystem().displayMetrics
+
         holder.view.layoutParams = (holder.view.layoutParams as RecyclerView.LayoutParams).apply {
-            val displayMetrics = Resources.getSystem().displayMetrics
 
             /* To show the edge of the next/previous card on the screen, we'll adjust the width of our MATCH_PARENT card to make
             it just slightly smaller than the screen. That way, no matter the size of the screen, the card will fill most of
@@ -62,13 +62,16 @@ class PollsRecyclerAdapter(
         }
 
         holder.bindPoll(poll, this, role)
+
         //Choices Recyclerview Height
         holder.view.pollsChoiceRecyclerView.layoutParams = (holder.view.pollsChoiceRecyclerView.layoutParams as ConstraintLayout.LayoutParams).apply {
-            val displayMetrics = Resources.getSystem().displayMetrics
-            val cellHeight = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 55f, displayMetrics).toInt()
-            val recyclerviewHeight = cellHeight * poll.answerChoices.count()
-            height = if (recyclerviewHeight <= 500) recyclerviewHeight else 500
+            val cellHeight = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 57f, displayMetrics).toInt()
+            matchConstraintMaxHeight = cellHeight * poll.answerChoices.count()
+            val adminMargin = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 120f, displayMetrics).toInt()
+            val memberMargin = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 20f, displayMetrics).toInt()
+            bottomMargin = if (role == User.Role.ADMIN) adminMargin else memberMargin
         }
+
         val childLayoutManager = LinearLayoutManager(holder.view.pollsChoiceRecyclerView.context)
         childLayoutManager.initialPrefetchItemCount = 4
         holder.view.pollsChoiceRecyclerView.apply {

--- a/app/src/main/res/drawable/rounded_poll_recyclerview.xml
+++ b/app/src/main/res/drawable/rounded_poll_recyclerview.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:padding="10dp"
+    android:shape="rectangle">
+    <solid android:color="@color/actualWhite" />
+    <corners
+        android:bottomLeftRadius="6dp"
+        android:bottomRightRadius="6dp" />
+</shape>

--- a/app/src/main/res/layout/poll_recyclerview_item_row.xml
+++ b/app/src/main/res/layout/poll_recyclerview_item_row.xml
@@ -241,7 +241,3 @@
             app:layout_constraintTop_toBottomOf="@+id/end_poll_button" />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>
-
-
-
-

--- a/app/src/main/res/layout/poll_recyclerview_item_row.xml
+++ b/app/src/main/res/layout/poll_recyclerview_item_row.xml
@@ -2,223 +2,224 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/pollsRecyclerViewCell"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:paddingBottom="10dp">
+
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/pollsRecyclerViewCell"
+        android:id="@+id/questionHeaderView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/rounded_poll_cell"
-        android:paddingBottom="10dp"
+        android:background="@drawable/rounded_poll_header"
+        app:layout_constraintBottom_toTopOf="@id/pollsChoiceRecyclerView"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0"
+        app:layout_constraintVertical_chainStyle="packed">
+
+        <TextView
+            android:id="@+id/questionMCTextView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="1dp"
+            android:layout_marginEnd="20dp"
+            android:fontFamily="sans-serif"
+            android:gravity="center"
+            android:letterSpacing="0.03"
+            android:text="Favorite Ice Cream \n Favorite Ice Cream \n Favorite Ice Cream"
+            android:textAlignment="center"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="HardcodedText" />
+
+        <LinearLayout
+            android:id="@+id/resultsSharedLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="@id/questionHeaderView"
+            app:layout_constraintTop_toBottomOf="@id/questionMCTextView">
+
+            <ImageView
+                android:id="@+id/resultsSharedIcon"
+                android:layout_width="15dp"
+                android:layout_height="15dp"
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="16dp"
+                android:src="@drawable/results_not_shared" />
+
+            <TextView
+                android:id="@+id/resultsSharedText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:fontFamily="sans-serif-medium"
+                android:text="Only you can see results"
+                android:textAlignment="center"
+                android:textColor="@color/settings_detail"
+                android:textSize="12sp"
+                android:textStyle="normal"
+                tools:ignore="HardcodedText" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/questionMCSubtitleText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:fontFamily="sans-serif-medium"
+            android:text="Final Results  •  1 Vote"
+            android:textAlignment="center"
+            android:textColor="@color/settings_detail"
+            android:textSize="12sp"
+            android:textStyle="normal"
+            app:layout_constraintTop_toBottomOf="@id/questionMCTextView"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:id="@+id/adminResponsesCount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:fontFamily="sans-serif-medium"
+            android:text="10 Responses"
+            android:textAlignment="center"
+            android:textColor="@color/settings_detail"
+            android:textSize="12sp"
+            android:textStyle="normal"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="@id/questionHeaderView"
+            app:layout_constraintTop_toBottomOf="@id/questionMCTextView"
+            tools:ignore="HardcodedText" />
+
+        <ImageButton
+            android:id="@+id/pollOptionsButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="1dp"
+            android:layout_marginTop="36dp"
+            android:layout_marginEnd="10dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/view_poll_options_content_description"
+            android:src="@drawable/more_dots"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <View
+            android:id="@+id/headerDivider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="32dp"
+            android:background="@color/settings_divider"
+            app:layout_constraintTop_toBottomOf="@+id/questionMCTextView" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/questionFRHeaderView"
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        android:background="@drawable/rounded_poll_header"
+        android:visibility="gone"
         app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/questionHeaderView"
+        <TextView
+            android:id="@+id/questionFRTextView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/rounded_poll_header"
-            app:layout_constraintBottom_toTopOf="@id/pollsChoiceRecyclerView"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <TextView
-                android:id="@+id/questionMCTextView"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="1dp"
-                android:layout_marginEnd="20dp"
-                android:fontFamily="sans-serif"
-                android:gravity="center"
-                android:letterSpacing="0.03"
-                android:text="Favorite Ice Cream \n Favorite Ice Cream \n Favorite Ice Cream"
-                android:textAlignment="center"
-                android:textColor="@color/black"
-                android:textSize="20sp"
-                android:textStyle="bold"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:ignore="HardcodedText" />
-
-            <LinearLayout
-                android:id="@+id/resultsSharedLayout"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:visibility="gone"
-                app:layout_constraintStart_toStartOf="@id/questionHeaderView"
-                app:layout_constraintTop_toBottomOf="@id/questionMCTextView">
-
-                <ImageView
-                    android:id="@+id/resultsSharedIcon"
-                    android:layout_width="15dp"
-                    android:layout_height="15dp"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginStart="16dp"
-                    android:src="@drawable/results_not_shared" />
-
-                <TextView
-                    android:id="@+id/resultsSharedText"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="10dp"
-                    android:fontFamily="sans-serif-medium"
-                    android:text="Only you can see results"
-                    android:textAlignment="center"
-                    android:textColor="@color/settings_detail"
-                    android:textSize="12sp"
-                    android:textStyle="normal"
-                    tools:ignore="HardcodedText" />
-            </LinearLayout>
-
-            <TextView
-                android:id="@+id/questionMCSubtitleText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:fontFamily="sans-serif-medium"
-                android:text="Final Results  •  1 Vote"
-                android:textAlignment="center"
-                android:textColor="@color/settings_detail"
-                android:textSize="12sp"
-                android:textStyle="normal"
-                app:layout_constraintTop_toBottomOf="@id/questionMCTextView"
-                tools:ignore="HardcodedText" />
-
-            <TextView
-                android:id="@+id/adminResponsesCount"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="16dp"
-                android:fontFamily="sans-serif-medium"
-                android:text="10 Responses"
-                android:textAlignment="center"
-                android:textColor="@color/settings_detail"
-                android:textSize="12sp"
-                android:textStyle="normal"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="@id/questionHeaderView"
-                app:layout_constraintTop_toBottomOf="@id/questionMCTextView"
-                tools:ignore="HardcodedText" />
-
-            <ImageButton
-                android:id="@+id/pollOptionsButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="1dp"
-                android:layout_marginTop="36dp"
-                android:layout_marginEnd="10dp"
-                android:background="@android:color/transparent"
-                android:contentDescription="@string/view_poll_options_content_description"
-                android:src="@drawable/more_dots"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <View
-                android:id="@+id/headerDivider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginTop="32dp"
-                android:background="@color/settings_divider"
-                app:layout_constraintTop_toBottomOf="@+id/questionMCTextView" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/questionFRHeaderView"
-            android:layout_width="match_parent"
-            android:layout_height="120dp"
-            android:background="@drawable/rounded_poll_header"
-            android:visibility="invisible"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <TextView
-                android:id="@+id/questionFRTextView"
-                android:layout_width="match_parent"
-                android:layout_height="60dp"
-                android:layout_marginTop="1dp"
-                android:fontFamily="sans-serif"
-                android:letterSpacing="0.03"
-                android:maxLines="3"
-                android:text="Favorite Ice Cream \n Favorite Ice Cream \n Favorite Ice Cream"
-                android:textAlignment="center"
-                android:textColor="@color/black"
-                android:textSize="20sp"
-                android:textStyle="bold"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:ignore="HardcodedText" />
-
-            <EditText
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="25dp"
-                android:layout_marginTop="27dp"
-                android:layout_marginEnd="25dp"
-                android:layout_marginBottom="30dp"
-                android:fontFamily="sans-serif-medium"
-                android:hint="Type a response"
-                android:inputType="text"
-                android:letterSpacing="0.02"
-                android:textColor="#c4c3c9"
-                android:textSize="16sp"
-                android:textStyle="normal"
-                android:visibility="invisible"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/questionFRTextView"
-                tools:ignore="HardcodedText,LabelFor" />
-
-            <TextView
-                android:id="@+id/questionFRSubtitleText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:fontFamily="sans-serif-medium"
-                android:text="Final Results  •  1 Vote"
-                android:textAlignment="center"
-                android:textColor="@color/settings_detail"
-                android:textSize="12sp"
-                android:textStyle="normal"
-                android:visibility="invisible"
-                app:layout_constraintTop_toBottomOf="@id/questionFRTextView"
-                tools:ignore="HardcodedText" />
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/settings_divider"
-                app:layout_constraintBottom_toBottomOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/pollsChoiceRecyclerView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/actualWhite"
-            android:scrollbars="vertical"
+            android:layout_height="60dp"
+            android:layout_marginTop="1dp"
+            android:fontFamily="sans-serif"
+            android:letterSpacing="0.03"
+            android:maxLines="3"
+            android:text="Favorite Ice Cream \n Favorite Ice Cream \n Favorite Ice Cream"
+            android:textAlignment="center"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/questionHeaderView" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="HardcodedText" />
+
+        <EditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="25dp"
+            android:layout_marginTop="27dp"
+            android:layout_marginEnd="25dp"
+            android:layout_marginBottom="30dp"
+            android:fontFamily="sans-serif-medium"
+            android:hint="Type a response"
+            android:inputType="text"
+            android:letterSpacing="0.02"
+            android:textColor="#c4c3c9"
+            android:textSize="16sp"
+            android:textStyle="normal"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/questionFRTextView"
+            tools:ignore="HardcodedText,LabelFor" />
+
+        <TextView
+            android:id="@+id/questionFRSubtitleText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:fontFamily="sans-serif-medium"
+            android:text="Final Results  •  1 Vote"
+            android:textAlignment="center"
+            android:textColor="@color/settings_detail"
+            android:textSize="12sp"
+            android:textStyle="normal"
+            android:visibility="invisible"
+            app:layout_constraintTop_toBottomOf="@id/questionFRTextView"
+            tools:ignore="HardcodedText" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/settings_divider"
+            app:layout_constraintBottom_toBottomOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/pollsChoiceRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginBottom="20dp"
+        android:background="@drawable/rounded_poll_recyclerview"
+        android:paddingBottom="10dp"
+        android:scrollbarFadeDuration="0"
+        android:scrollbars="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/questionHeaderView" />
 
     <LinearLayout
         android:id="@+id/adminPollControlsView"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
+        android:layout_height="100dp"
+        android:layout_marginTop="20dp"
         android:gravity="center_horizontal"
         android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/pollsRecyclerViewCell">
+        app:layout_constraintTop_toBottomOf="@id/pollsChoiceRecyclerView">
 
         <Button
             android:id="@+id/end_poll_button"
             android:layout_width="wrap_content"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:background="@drawable/rounded_container_outline"
             android:paddingLeft="30dp"
             android:paddingRight="30dp"
@@ -240,3 +241,7 @@
             app:layout_constraintTop_toBottomOf="@+id/end_poll_button" />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+
+


### PR DESCRIPTION




  ## Overview

  <!-- Summarize your changes here. -->
Poll height will adjust based on screen size
join group editext problem debugged by disabling IME dictionary suggestion
26 limit for poll choices

  ## Changes Made
1. Re-structure the poll_recyclerview_item_row.xml layout, include adminPollControlsView inside the main layout
2. make poll height adjust base on the screen size and user Role by adding additional constraints and constraint bias
3. When user Role is Admin, the bottom margin for the recyclerview =120 to include the end poll and time count view
4. When user Role is member, the bottom margin for the recyclerview =20
5. the add option button will disappear when there are 26 choices, and reappear if any choices are deleted. 
6. Debug delete button not disappear once a saved poll of two choices get clicked
7. join group edit text will not have a dictionary suggestion so that the weird duplication and unable to delete will not appear.
 



  ## Test Coverage

I manually test on the emulator and my own phone, it all works as intended
Devices Pixel 2XL API 29, Pixel 2 API 29, Huawei Mate 20, they all have different screen sizes. 


 